### PR TITLE
LPS-156136 Avoid redundant fetchLayout call as Layout#isPublished will also check existence of the draft layout. This cuts half of the fetchLayout calls on a content page when CT is enabled.

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/theme/NavItem.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/NavItem.java
@@ -397,8 +397,8 @@ public class NavItem implements Serializable {
 			return false;
 		}
 
-		if (layout.fetchDraftLayout() != null) {
-			return !layout.isPublished();
+		if (layout.isPublished()) {
+			return false;
 		}
 
 		if (layout.isApproved() && !layout.isHidden() && !layout.isSystem()) {


### PR DESCRIPTION
@tinatian This is one thing that I found today. I haven't tested it myself, but from profile it should cut half of the fetchLayout calls from NavItem, which contributes the most major part of these calls.