### PR TITLE
LPS-157454 Part 1: Cache LayoutStructure in ContentPageEditorDisplayContext

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -53,6 +53,7 @@ import com.liferay.item.selector.criteria.info.item.criterion.InfoListItemSelect
 import com.liferay.item.selector.criteria.url.criterion.URLItemSelectorCriterion;
 import com.liferay.item.selector.criteria.video.criterion.VideoItemSelectorCriterion;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.constants.LayoutWebKeys;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.sidebar.panel.ContentPageEditorSidebarPanel;
 import com.liferay.layout.content.page.editor.web.internal.configuration.PageEditorConfiguration;
@@ -1675,9 +1676,19 @@ public class ContentPageEditorDisplayContext {
 			return _layoutStructure;
 		}
 
+		_layoutStructure = (LayoutStructure)httpServletRequest.getAttribute(
+			LayoutWebKeys.LAYOUT_STRUCTURE);
+
+		if (_layoutStructure != null) {
+			return _layoutStructure;
+		}
+
 		_layoutStructure = LayoutStructureUtil.getLayoutStructure(
 			themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
 			getSegmentsExperienceId());
+
+		httpServletRequest.setAttribute(
+			LayoutWebKeys.LAYOUT_STRUCTURE, _layoutStructure);
 
 		return _layoutStructure;
 	}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -218,6 +218,8 @@ public class ContentPageEditorDisplayContext {
 	public Map<String, Object> getEditorContext(String npmResolvedPackageName)
 		throws Exception {
 
+		LayoutStructure layoutStructure = _getLayoutStructure();
+
 		return HashMapBuilder.<String, Object>put(
 			"config",
 			HashMapBuilder.<String, Object>put(
@@ -673,12 +675,7 @@ public class ContentPageEditorDisplayContext {
 				"languageId",
 				LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale())
 			).put(
-				"layoutData",
-				() -> {
-					LayoutStructure layoutStructure = _getLayoutStructure();
-
-					return layoutStructure.toJSONObject();
-				}
+				"layoutData", layoutStructure.toJSONObject()
 			).put(
 				"mappingFields", _getMappingFieldsJSONObject()
 			).put(


### PR DESCRIPTION
@tinatian This can reduce unnecessary calls related to LayoutStructure. I think this is safe becasue this caching only affects editing the content page, and I just cache the instance as is. We can apply this first, and let Echo Team provide the universal solution.