### PR TITLE
LPS-157454 Part 1: Cache LayoutStructure in ContentPageEditorDisplayContext | init in constructor

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -80,6 +80,7 @@ import com.liferay.layout.util.structure.DropZoneLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
@@ -213,6 +214,13 @@ public class ContentPageEditorDisplayContext {
 
 		themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
+
+		try {
+			_getLayoutStructure();
+		}
+		catch (Exception exception) {
+			ReflectionUtil.throwException(exception);
+		}
 	}
 
 	public Map<String, Object> getEditorContext(String npmResolvedPackageName)
@@ -673,12 +681,7 @@ public class ContentPageEditorDisplayContext {
 				"languageId",
 				LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale())
 			).put(
-				"layoutData",
-				() -> {
-					LayoutStructure layoutStructure = _getLayoutStructure();
-
-					return layoutStructure.toJSONObject();
-				}
+				"layoutData", _layoutStructure.toJSONObject()
 			).put(
 				"mappingFields", _getMappingFieldsJSONObject()
 			).put(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -216,7 +216,7 @@ public class ContentPageEditorDisplayContext {
 			WebKeys.THEME_DISPLAY);
 
 		try {
-			_getLayoutStructure();
+			_initLayoutStructure();
 		}
 		catch (Exception exception) {
 			ReflectionUtil.throwException(exception);
@@ -1438,7 +1438,7 @@ public class ContentPageEditorDisplayContext {
 					getGroupId(), getSegmentsExperienceId(),
 					themeDisplay.getPlid());
 
-		LayoutStructure layoutStructure = _getLayoutStructure();
+		LayoutStructure layoutStructure = _initLayoutStructure();
 
 		Map<String, Object> fragmentEntryLinksMap = new HashMap<>(
 			_getFragmentEntryLinksMap(
@@ -1514,7 +1514,7 @@ public class ContentPageEditorDisplayContext {
 					LayoutStructureUtil.
 						getCollectionStyledLayoutStructureItemIds(
 							fragmentEntryLink.getFragmentEntryLinkId(),
-							_getLayoutStructure()));
+							_initLayoutStructure()));
 
 			JSONObject jsonObject =
 				_fragmentEntryLinkManager.getFragmentEntryLinkJSONObject(
@@ -1672,28 +1672,6 @@ public class ContentPageEditorDisplayContext {
 				RequestBackedPortletURLFactoryUtil.create(httpServletRequest),
 				_renderResponse.getNamespace() + "selectLayout",
 				layoutItemSelectorCriterion));
-	}
-
-	private LayoutStructure _getLayoutStructure() throws Exception {
-		if (_layoutStructure != null) {
-			return _layoutStructure;
-		}
-
-		_layoutStructure = (LayoutStructure)httpServletRequest.getAttribute(
-			LayoutWebKeys.LAYOUT_STRUCTURE);
-
-		if (_layoutStructure != null) {
-			return _layoutStructure;
-		}
-
-		_layoutStructure = LayoutStructureUtil.getLayoutStructure(
-			themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
-			getSegmentsExperienceId());
-
-		httpServletRequest.setAttribute(
-			LayoutWebKeys.LAYOUT_STRUCTURE, _layoutStructure);
-
-		return _layoutStructure;
 	}
 
 	private int _getLayoutType() {
@@ -2077,6 +2055,28 @@ public class ContentPageEditorDisplayContext {
 		}
 
 		return false;
+	}
+
+	private LayoutStructure _initLayoutStructure() throws Exception {
+		if (_layoutStructure != null) {
+			return _layoutStructure;
+		}
+
+		_layoutStructure = (LayoutStructure)httpServletRequest.getAttribute(
+			LayoutWebKeys.LAYOUT_STRUCTURE);
+
+		if (_layoutStructure != null) {
+			return _layoutStructure;
+		}
+
+		_layoutStructure = LayoutStructureUtil.getLayoutStructure(
+			themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
+			getSegmentsExperienceId());
+
+		httpServletRequest.setAttribute(
+			LayoutWebKeys.LAYOUT_STRUCTURE, _layoutStructure);
+
+		return _layoutStructure;
 	}
 
 	private boolean _isAllowedFragmentEntryKey(String fragmentEntryKey) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -53,6 +53,7 @@ import com.liferay.item.selector.criteria.info.item.criterion.InfoListItemSelect
 import com.liferay.item.selector.criteria.url.criterion.URLItemSelectorCriterion;
 import com.liferay.item.selector.criteria.video.criterion.VideoItemSelectorCriterion;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.constants.LayoutWebKeys;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.sidebar.panel.ContentPageEditorSidebarPanel;
 import com.liferay.layout.content.page.editor.web.internal.configuration.PageEditorConfiguration;
@@ -1675,9 +1676,19 @@ public class ContentPageEditorDisplayContext {
 			return _layoutStructure;
 		}
 
+		_layoutStructure = (LayoutStructure)httpServletRequest.getAttribute(
+			LayoutWebKeys.LAYOUT_STRUCTURE);
+
+		if (_layoutStructure != null) {
+			return _layoutStructure;
+		}
+
 		_layoutStructure = LayoutStructureUtil.getLayoutStructure(
 			themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
 			getSegmentsExperienceId());
+
+		httpServletRequest.setAttribute(
+			LayoutWebKeys.LAYOUT_STRUCTURE, _layoutStructure);
 
 		return _layoutStructure;
 	}


### PR DESCRIPTION
@tinatian This is basically same with https://github.com/liferay-publications/liferay-portal/pull/140, I just moved LayoutStructure to constructor as Echo Team confirms that both portlets are always on the same page..