### PR TITLE
LPS-162683 Fix overly broad INNER JOIN condition in LayoutTableReferenceDefinition

### DIFF
--- a/modules/apps/site/site-service/src/main/java/com/liferay/site/internal/change/tracking/spi/reference/LayoutTableReferenceDefinition.java
+++ b/modules/apps/site/site-service/src/main/java/com/liferay/site/internal/change/tracking/spi/reference/LayoutTableReferenceDefinition.java
@@ -114,7 +114,14 @@ public class LayoutTableReferenceDefinition
 				).innerJoinON(
 					LayoutTable.INSTANCE,
 					LayoutTable.INSTANCE.parentLayoutId.eq(
-						aliasLayoutTable.layoutId)
+						aliasLayoutTable.layoutId
+					).and(
+						LayoutTable.INSTANCE.groupId.eq(
+							aliasLayoutTable.groupId)
+					).and(
+						LayoutTable.INSTANCE.privateLayout.eq(
+							aliasLayoutTable.privateLayout)
+					)
 				);
 			}
 		).referenceInnerJoin(


### PR DESCRIPTION
Motivation
=======
The problem is described in detail in [LPS-162683](https://issues.liferay.com/browse/LPS-162683).

When loading the "Discarded Changes" page in Publications, Liferay generates a map that maps the parent assets to their children. This map is used to render the complete list of relevant changes that will be discarded on all the asset's children when that asset's changes are discarded.

However, in the case of Layouts, the map can generate false children, which can cause it to become even more bloated than it already is, thereby introducing possible performance issues. This is because one of the ways that we map the parent layout to its children is by using the "parentLayoutId" and "layoutId" values. However, this by itself is far too broad. The "layoutId" is NOT expected to be unique across the entire publication. The "layoutId" is expected to be unique across (groupId, privateLayout) values across the publication.

Proposed Solution
========
Modified the INNER JOIN condition in the LayoutTableReferenceDefinition class to be:

```
parentTable.layoutId = childTable.parentLayoutId
AND parentTable.groupId = childTable.groupId
AND parentTable.privateLayout = childTable.privateLayout
```

instead of just:

`parentTable.layoutId = childTable.parentLayoutId`

Steps to Verify
========
1. Start up Liferay and log in as the admin user.
2. From the default Liferay DXP Site, navigate to Site Builder > Pages.
3. Select the first Public Page (more rigorously, the one that has layoutId = 1), and add a Public Child Page of type Widget Page to it (in my testing in master, the "first Public Page" was the Search page). Name the page "Child Page"
4. Navigate to [Global Menu] > Control Panel > Sites and create a new Site called "Test Site".
5. Create a new Public Content Page on the "Test Site" called "Test Page".
6. Navigate to [Global Menu] > Applications > Publications.
7. Toggle the "Enable Publications" slider to the enabled position and click Save.
8. Click the Production dropdown at the top and select "+ Create New Publication". Name it "Test Publication" and click the Create button.
9. Navigate to the "Child Page" on the default Liferay DXP Site on the "Test Publication" and add any portlet to it.
10. Switch to Production by clicking on the Test Publication dropdown at the top and selecting "Work on Production".
11. On Production, add a different portlet to the Liferay DXP Site than the one you added in step xx.
12. Switch back to the Test Publication by clicking on the Production dropdown at the top and then Select a Publication > Test Publication.
13. Repeat steps 9-12, but for the "Test Page" on the "Test Site" instead of the "Child Page" on the default Liferay DXP Site.
14. Now click on the Test Publication dropdown at the top and select Review Changes.
15. Click the Publish button.
16. A list of several conflicts should be shown, including one for "Child Page" and "Test Page".
17. Click on the down arrow in the "Edit in Test Publication" Menu next to the "Test Page", and select "Discard Changes".

**Expected Result:** The "Discarded Changes" page would only display changes related to "Test Page".
**Actual Result:** The "Discarded Changes" page displays changes related to both "Test Page" and "Child Page", even though "Child Page" is unrelated to "Test Page".