### PR TITLE
[TS] LPS-163295 Set CompanyThreadLocal to use correct companyId

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java
@@ -24,9 +24,12 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
+import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
 import com.liferay.portal.workflow.kaleo.runtime.graph.GraphWalker;
 import com.liferay.portal.workflow.kaleo.runtime.graph.PathElement;
 
@@ -59,13 +62,22 @@ public class GraphWalkerPortalExecutor {
 			return;
 		}
 
+		ExecutionContext executionContext = pathElement.getExecutionContext();
+
+		ServiceContext serviceContext = executionContext.getServiceContext();
+
+		long companyId = serviceContext.getCompanyId();
+
 		long ctCollectionId = CTCollectionThreadLocal.getCTCollectionId();
 
 		if (waitForCompletion) {
 			NoticeableFuture<?> noticeableFuture =
 				_noticeableExecutorService.submit(
 					() -> {
-						try (SafeCloseable safeCloseable =
+						try (SafeCloseable safeCloseable1 =
+								CompanyThreadLocal.setWithSafeCloseable(
+									companyId);
+							SafeCloseable safeCloseable2 =
 								CTCollectionThreadLocal.
 									setCTCollectionIdWithSafeCloseable(
 										ctCollectionId)) {
@@ -87,7 +99,9 @@ public class GraphWalkerPortalExecutor {
 		else {
 			_noticeableExecutorService.submit(
 				() -> {
-					try (SafeCloseable safeCloseable =
+					try (SafeCloseable safeCloseable1 =
+							CompanyThreadLocal.setWithSafeCloseable(companyId);
+						SafeCloseable safeCloseable2 =
 							CTCollectionThreadLocal.
 								setCTCollectionIdWithSafeCloseable(
 									ctCollectionId)) {


### PR DESCRIPTION
Hi Publications Team,

/cc @ctang3 

Can you help review this PR?

For additional context + analysis, please see below.

Please let me know if you have any questions.
Thanks!

----

**Context**
https://issues.liferay.com/browse/LPS-163295

Per our discussion via [PTR-3353](https://issues.liferay.com/browse/PTR-3353) + Slack Thread, we are focusing on getting these two main factors to work with Workflows:
- DB Partitioning
- Publications

From my understanding, to get these two to work properly with Workflows:
- DB Partitioning relies on setting the correct **companyId** via **CompanyThreadLocal**
- Publications relies on setting the correct **ctCollectionId** via **CTCollectionThreadLocal**

**Analysis**
The main cause of confusion is due to the current implementation of **CompanyThreadLocal.setWithSafeCloseable**:
[CompanyThreadLocal.java#L109-L110](https://github.com/liferay/liferay-portal/blob/7.4.3.44-ga44/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java#L109-L110)
- As we can see, setting companyId in CompanyThreadLocal forces CTCollectionThreadLocal to use ProductionMode (ctCollectionId=0)

I'm assuming that's why this commit: [LPS-117628 Fix Production scoping bug now that Kaleo is change tracked ](https://github.com/liferay/liferay-portal/commit/6ef8cc82f4924b4a287a3441f5708b67efc574cf) was needed to get publications to work with Workflows.
- The call to **CompanyThreadLocal.setWithSafeCloseable** was causing ctCollectionId to be set to 0 in CTCollectionThreadLocal
- But as a result of this commit, this introduced issues when using DB Partitioning

**Proposed Fix**
The proposed fix works around this behavior by:
- First setting the CompanyThreadLocal with the correct companyId (which also sets ctCollectionId=0 in CTCollectionThreadLocal)
- Then setting the CTCollectionThreadLocal with the correct ctCollectionId

This makes it so the correct **ctCollectionId** is set, and the correct **companyId** is set as well.

**Additional Thoughts**
One question to ask would be - should **CompanyThreadLocal.setWithSafeCloseable** always set CTCollectionThreadLocal to use Production Mode (ctCollectionId=0)?