### PR TITLE
LPS-168508: Fix to be able select PublicationRoleConstants.ROLE_VIEWER

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ManageCollaborators.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ManageCollaborators.js
@@ -668,7 +668,7 @@ const ManageCollaborators = ({
 				}
 			}
 
-			if (role.value > 0) {
+			if (role.value >= 0) {
 				json[user.userId.toString()] = role;
 			}
 


### PR DESCRIPTION
Hi team,
This is related to the ticket: https://issues.liferay.com/browse/LPS-168508
It fix is to resolve an issue that cannot update the Viewer role as PublicationRoleConstants.ROLE_VIEWER = 0
@tototrinh
Please help to review.
Thanks