### PR TITLE
LPS-179333 Check for null

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/conflict/CTConflictChecker.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/conflict/CTConflictChecker.java
@@ -929,14 +929,17 @@ public class CTConflictChecker<T extends CTModel<T>> {
 
 			while (resultSet.next()) {
 				long pk = resultSet.getLong(1);
-				long mvccVersion = resultSet.getLong(2);
 
 				CTEntry ctEntry = _modificationCTEntries.get(pk);
 
-				ctEntry.setModifiedDate(ctEntry.getModifiedDate());
-				ctEntry.setModelMvccVersion(mvccVersion);
+				if (ctEntry != null) {
+					long mvccVersion = resultSet.getLong(2);
 
-				_ctEntryLocalService.updateCTEntry(ctEntry);
+					ctEntry.setModifiedDate(ctEntry.getModifiedDate());
+					ctEntry.setModelMvccVersion(mvccVersion);
+
+					_ctEntryLocalService.updateCTEntry(ctEntry);
+				}
 			}
 		}
 		catch (SQLException sqlException) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-179333

After implementing the timeline, the ctEntries being passed into the conflict checker doesn't always match the values returned in _updateModelMvccVersion. Therefore, _modificationCTEntries.get(pk) could return null.