### PR TITLE
LPS-184911 If Publications is being disabled or remaining disabled then redirect to the settings screen

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/UpdateGlobalPublicationsConfigurationMVCActionCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/UpdateGlobalPublicationsConfigurationMVCActionCommand.java
@@ -71,11 +71,6 @@ public class UpdateGlobalPublicationsConfigurationMVCActionCommand
 			_ctSettingsConfigurationHelper.getCTSettingsConfiguration(
 				companyId);
 
-		if (ctSettingsConfiguration.enabled()) {
-			redirectURL.setParameter(
-				"mvcRenderCommandName", "/change_tracking/view_settings");
-		}
-
 		boolean enablePublications = ParamUtil.getBoolean(
 			actionRequest, "enablePublications",
 			ctSettingsConfiguration.enabled());
@@ -85,6 +80,11 @@ public class UpdateGlobalPublicationsConfigurationMVCActionCommand
 		boolean enableUnapprovedChanges = ParamUtil.getBoolean(
 			actionRequest, "enableUnapprovedChanges",
 			ctSettingsConfiguration.unapprovedChangesAllowed());
+
+		if (ctSettingsConfiguration.enabled() || !enablePublications) {
+			redirectURL.setParameter(
+				"mvcRenderCommandName", "/change_tracking/view_settings");
+		}
 
 		try {
 			_portletPermission.check(


### PR DESCRIPTION
This check was previously implemented but removed as part of LPS-154710 (https://github.com/liferay/liferay-portal/commit/f5b4c5e637e65357945d2e576c700c3a29a8e2a6#diff-b11ed88d2005a48a70721c99e45d5f65fee3bca734a95415fd4e26fdebdccbc2L85).

I couldn't see a reason why the check was removed but please let me know if there was and I can come up with a different fix.