### PR TITLE
LPS-190241 Right side of the Split View should show the Publication's name

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
@@ -166,7 +166,7 @@ public class GetEntryRenderDataMVCResourceCommand
 		String rightTitle = null;
 
 		if (ctEntry.getChangeType() != CTConstants.CT_CHANGE_TYPE_DELETION) {
-			rightTitle = _language.get(httpServletRequest, "publication");
+			rightTitle = ctCollection.getName();
 
 			long ctCollectionId = ctCollection.getCtCollectionId();
 
@@ -321,8 +321,7 @@ public class GetEntryRenderDataMVCResourceCommand
 
 					rightTitle = StringBundler.concat(
 						_language.get(httpServletRequest, "version"), ": ",
-						rightVersionName, " (",
-						_language.get(httpServletRequest, "publication"), ")");
+						rightVersionName, " (", ctCollection.getName(), ")");
 
 					if (ArrayUtil.isNotEmpty(availableLanguageIds)) {
 						leftLocalizedPreviewJSONObject =
@@ -470,14 +469,12 @@ public class GetEntryRenderDataMVCResourceCommand
 						rightModel);
 
 					if (Validator.isNull(rightVersionName)) {
-						rightTitle = _language.get(
-							httpServletRequest, "publication");
+						rightTitle = ctCollection.getName();
 					}
 					else {
 						rightTitle = StringBundler.concat(
 							_language.get(httpServletRequest, "version"), ": ",
-							rightVersionName, " (",
-							_language.get(httpServletRequest, "publication"),
+							rightVersionName, " (", ctCollection.getName(),
 							")");
 					}
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
@@ -1057,7 +1057,7 @@ export default function ChangeTrackingRenderView({
 
 						{
 							<td className="publications-render-view-divider">
-								{Liferay.Language.get('publication')}
+								{state.renderData.rightTitle}
 							</td>
 						}
 					</tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-190241

@david-truong 

Right side now shows the publication's name instead of a generic "PUBLICATION" like below: 

![image](https://github.com/liferay-publications/liferay-portal/assets/25592431/645cf127-d50b-472e-9f67-2b63acaff164)
