### PR TITLE
[TECHNICAL SUPPORT] LPS-131014 Cannot remove vocabulary within a publication.

### DIFF
--- a/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountRelLocalServiceImpl.java
@@ -31,6 +31,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
+import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
@@ -58,6 +59,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = "model.class.name=com.liferay.commerce.discount.model.CommerceDiscountRel",
 	service = AopService.class
 )
+@CTAware
 public class CommerceDiscountRelLocalServiceImpl
 	extends CommerceDiscountRelLocalServiceBaseImpl {
 


### PR DESCRIPTION
### 🐛  Issue
You **cannot remove vocabulary within a publication** because it throws a `CTTransactionException`.

### 📖  Content
- **LPS-131014**
  - Added the `CTAware` annotation to the `CommerceDiscountRelLocalServiceImpl` class.

### 🧪 How To Test
- Start a clean bundle.
- Login as admin.
- Go to [Applications > Publications] and enable it.
  - **Create a Publication**.
- Go to [Liferay DXP > Categorization > Categories > ➕ ] and add a **new vocabulary**.
- Go to [➕ ] and add a **new category**.
- Click on vocabulary's ⋮ and select **Delete**.

### ✅ Expected result
Vocabulary is deleted successfully.

### 🙏🏻 Thanks for the review in advance.

Regards,
Márkó