### PR TITLE
LPS-204851 Avoid showing the discard URL if the collection is in a read-only status

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -199,7 +199,7 @@ public class ViewChangesDisplayContext {
 	}
 
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		return ListUtil.fromArray(
+		List<FDSActionDropdownItem> fdsActionDropdownItems = ListUtil.fromArray(
 			new FDSActionDropdownItem(
 				PortletURLBuilder.createRenderURL(
 					_renderResponse
@@ -231,24 +231,32 @@ public class ViewChangesDisplayContext {
 				).buildString(),
 				"move-folder", "move-changes",
 				_language.get(_httpServletRequest, "move-changes"), "post",
-				"move-changes", null),
-			new FDSActionDropdownItem(
-				PortletURLBuilder.createRenderURL(
-					_renderResponse
-				).setMVCRenderCommandName(
-					"/change_tracking/view_discard"
-				).setRedirect(
-					_themeDisplay.getURLCurrent()
-				).setParameter(
-					"ctCollectionId", "{ctCollectionId}"
-				).setParameter(
-					"modelClassNameId", "{modelClassNameId}"
-				).setParameter(
-					"modelClassPK", "{modelClassPK}"
-				).buildString(),
-				"times-circle", "view-discard",
-				_language.get(_httpServletRequest, "discard"), "get",
-				"view-discard", null));
+				"move-changes", null));
+
+		if ((_ctCollection.getStatus() == WorkflowConstants.STATUS_DRAFT) ||
+			(_ctCollection.getStatus() == WorkflowConstants.STATUS_PENDING)) {
+
+			fdsActionDropdownItems.add(
+				new FDSActionDropdownItem(
+					PortletURLBuilder.createRenderURL(
+						_renderResponse
+					).setMVCRenderCommandName(
+						"/change_tracking/view_discard"
+					).setRedirect(
+						_themeDisplay.getURLCurrent()
+					).setParameter(
+						"ctCollectionId", "{ctCollectionId}"
+					).setParameter(
+						"modelClassNameId", "{modelClassNameId}"
+					).setParameter(
+						"modelClassPK", "{modelClassPK}"
+					).buildString(),
+					"times-circle", "view-discard",
+					_language.get(_httpServletRequest, "discard"), "get",
+					"view-discard", null));
+		}
+
+		return fdsActionDropdownItems;
 	}
 
 	public List<FDSFilter> getFDSFilters() {
@@ -481,23 +489,33 @@ public class ViewChangesDisplayContext {
 			)
 		).put(
 			"discardURL",
-			PortletURLBuilder.createRenderURL(
-				_renderResponse
-			).setMVCRenderCommandName(
-				"/change_tracking/view_discard"
-			).setRedirect(
-				PortletURLBuilder.createRenderURL(
+			() -> {
+				if ((_ctCollection.getStatus() !=
+						WorkflowConstants.STATUS_DRAFT) &&
+					(_ctCollection.getStatus() !=
+						WorkflowConstants.STATUS_PENDING)) {
+
+					return null;
+				}
+
+				return PortletURLBuilder.createRenderURL(
 					_renderResponse
 				).setMVCRenderCommandName(
-					"/change_tracking/view_changes"
+					"/change_tracking/view_discard"
+				).setRedirect(
+					PortletURLBuilder.createRenderURL(
+						_renderResponse
+					).setMVCRenderCommandName(
+						"/change_tracking/view_changes"
+					).setParameter(
+						"ctCollectionId", _ctCollection.getCtCollectionId()
+					).buildString()
+				).setBackURL(
+					_themeDisplay.getURLCurrent()
 				).setParameter(
 					"ctCollectionId", _ctCollection.getCtCollectionId()
-				).buildString()
-			).setBackURL(
-				_themeDisplay.getURLCurrent()
-			).setParameter(
-				"ctCollectionId", _ctCollection.getCtCollectionId()
-			).buildString()
+				).buildString();
+			}
 		).put(
 			"entryFromURL", ParamUtil.getString(_renderRequest, "entry")
 		).put(

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
@@ -189,22 +189,28 @@ public class GetEntryRenderDataMVCResourceCommand
 				ctEntry.getModelClassPK());
 
 			if (rightModel != null) {
-				String editURL = _ctDisplayRendererRegistry.getEditURL(
-					ctCollectionId, ctSQLMode, httpServletRequest, rightModel,
-					ctEntry.getModelClassNameId());
+				if ((ctCollection.getStatus() ==
+						WorkflowConstants.STATUS_DRAFT) ||
+					(ctCollection.getStatus() ==
+						WorkflowConstants.STATUS_PENDING)) {
 
-				if (Validator.isNotNull(editURL)) {
-					editInPublicationJSONObject = _getEditJSONObject(
-						_language.format(
-							httpServletRequest,
-							"you-are-currently-working-on-production.-work-" +
-								"on-x",
-							new Object[] {ctCollection.getName()}, false),
-						ctCollection.getCtCollectionId(), editURL,
-						_language.format(
-							httpServletRequest, "edit-in-x",
-							new Object[] {ctCollection.getName()}, false),
-						resourceRequest, resourceResponse);
+					String editURL = _ctDisplayRendererRegistry.getEditURL(
+						ctCollectionId, ctSQLMode, httpServletRequest,
+						rightModel, ctEntry.getModelClassNameId());
+
+					if (Validator.isNotNull(editURL)) {
+						editInPublicationJSONObject = _getEditJSONObject(
+							_language.format(
+								httpServletRequest,
+								"you-are-currently-working-on-production.-" +
+									"work-on-x",
+								new Object[] {ctCollection.getName()}, false),
+							ctCollection.getCtCollectionId(), editURL,
+							_language.format(
+								httpServletRequest, "edit-in-x",
+								new Object[] {ctCollection.getName()}, false),
+							resourceRequest, resourceResponse);
+					}
 				}
 
 				if (localize) {

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingChangeView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingChangeView.js
@@ -345,6 +345,10 @@ export default function ChangeTrackingChangeView({
 
 	const getDiscardURL = useCallback(
 		(node) => {
+			if (!discardURL) {
+				return null;
+			}
+
 			const url = setParameter(
 				discardURL,
 				'modelClassNameId',

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
@@ -765,6 +765,10 @@ export default function ChangeTrackingRenderView({
 			});
 		}
 
+		if (!dropdownItems.length) {
+			return null;
+		}
+
 		return (
 			<div className="autofit-col">
 				<ClayDropDownWithItems

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
@@ -757,11 +757,13 @@ export default function ChangeTrackingRenderView({
 			});
 		}
 
-		dropdownItems.push({
-			label: Liferay.Language.get('discard'),
-			onClick: () => navigateUtil(discardURL),
-			symbolLeft: 'times-circle',
-		});
+		if (discardURL !== null) {
+			dropdownItems.push({
+				label: Liferay.Language.get('discard'),
+				onClick: () => navigateUtil(discardURL),
+				symbolLeft: 'times-circle',
+			});
+		}
 
 		return (
 			<div className="autofit-col">


### PR DESCRIPTION
Ticket: [LPS-204851](https://liferay.atlassian.net/browse/LPS-204851)

It is not supported to discard changes from a read-only publication (such as an already-published one). See [PTR-4618](https://liferay.atlassian.net/browse/PTR-4618). Therefore, we should prevent the option from appearing in the UI for such publications.

Note: I wasn't able to test how the UI looks correctly due to the [Windows bug](https://liferay.slack.com/archives/C03CAD9EF/p1697788792736759?thread_ts=1697788558.585849&cid=C03CAD9EF) with the Frontend Dataset component. If one of you could test this, that would be nice. I was at least able to verify that the option to discard no longer appears in the UI for published Publications, I just don't know how that UI would normally look for a properly-compiled Frontend Dataset component.