### PR TITLE
LPD-15362 Trim namespace in PublicationTimeline

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/PublicationTimeline.js
@@ -6,7 +6,7 @@
 import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayPanel from '@clayui/panel';
-import {createPortletURL, fetch} from 'frontend-js-web';
+import {createPortletURL, fetch, getPortletId} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import TimelineDropdownMenu from './TimelineDropdownMenu';
@@ -31,7 +31,7 @@ const PublicationTimeline = ({namespace, timelineItemsURL}) => {
 			{
 				ctCollectionId,
 				mvcRenderCommandName,
-				p_p_id: namespace,
+				p_p_id: getPortletId(namespace),
 				...additionalParams,
 			}
 		).toString();


### PR DESCRIPTION
While verifying https://liferay.atlassian.net/browse/LPD-15362 after it was merged into master, I noticed that the action links for each timeline item were broken. 

The namespace PublicationTimeline.js gets from it's parent is formed by this call in the backend:  `_portal.getPortletNamespace(CTPortletKeys.PUBLICATIONS)`, where `getPortletNamespace(...)` wraps the namespace in underscores for it to be used in certain other requests.