### PR TITLE
LPD-20140 Allow changes to be moved from an out of date publication

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -831,7 +831,9 @@ public class CTCollectionLocalServiceImpl
 
 		if ((fromCTCollection.getStatus() != WorkflowConstants.STATUS_DRAFT) &&
 			(fromCTCollection.getStatus() !=
-				WorkflowConstants.STATUS_PENDING)) {
+				WorkflowConstants.STATUS_PENDING) &&
+			(fromCTCollection.getStatus() !=
+				WorkflowConstants.STATUS_EXPIRED)) {
 
 			throw new CTCollectionStatusException(
 				"Change tracking collection " + fromCTCollection +

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -217,6 +217,27 @@ public class ViewChangesDisplayContext {
 				_language.get(_httpServletRequest, "review-change"), "get",
 				"get", null));
 
+		if (_ctCollection.getStatus() == WorkflowConstants.STATUS_EXPIRED) {
+			fdsActionDropdownItems.add(
+				new FDSActionDropdownItem(
+					PortletURLBuilder.createRenderURL(
+						_renderResponse
+					).setMVCRenderCommandName(
+						"/change_tracking/view_move_changes"
+					).setRedirect(
+						_themeDisplay.getURLCurrent()
+					).setParameter(
+						"ctCollectionId", "{ctCollectionId}"
+					).setParameter(
+						"modelClassNameId", "{modelClassNameId}"
+					).setParameter(
+						"modelClassPK", "{modelClassPK}"
+					).buildString(),
+					"move-folder", "move-changes",
+					_language.get(_httpServletRequest, "move-changes"), "post",
+					"move-changes", null));
+		}
+
 		if (_ctCollection.getStatus() == WorkflowConstants.STATUS_DRAFT) {
 			fdsActionDropdownItems.add(
 				new FDSActionDropdownItem(

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -19363,7 +19363,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing.
 this-publication-no-longer-exists=This publication no longer exists.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication.
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it.
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=يحتوي هذا المنشور على تغييرات غير معتمدة.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=يحتوي هذا المنشور على تغييرات غير معتمدة والتي يجب حلها قبل النشر.
 this-publication-no-longer-exists=هذا المنشور لم يعد موجودًا.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=تم إنشاء هذا المنشور على إصدار سابق من Liferay. لا يمكنك نشره أو التراجع عنه أو إجراء تغييرات إضافية عليه. يمكنك فقط عرضه أو حذفه.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=تم إنشاء هذا المنشور على إصدار سابق من Liferay. لا يمكنك التراجع عنه.
 this-question-is-closed-new-answers-and-comments-are-disabled=هذا السؤال مغلق. تم تعطيل الإجابات والتعليقات الجديدة.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=هذا التصنيف لم يعد قابلاً للتطبيق على عمليات البحث نظرًا لأنه تم حذف المخطط الأولي الذي كان مرتبطًا به.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Тази публикация вече не съществува. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Тази публикация е създадена на предишна Liferay версия. Не можете да публикувате, връщате или да правите допълнителни промени. Можете да го преглеждате или изтривате само. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Тази публикация е създадена на предишна Liferay версия. Не можеш да го възвърнеш. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Този въпрос е затворен. Нови отговори и коментари са забранени. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -19359,7 +19359,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=Aquesta publicació conté canvis no aprovats.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=Aquesta publicació conté canvis no aprovats que s'han d'aprovar manualment abans de publicar-la.
 this-publication-no-longer-exists=Aquesta publicació ja no existeix.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Aquesta publicació es va crear en una versió anterior de Liferay. No es pot publicar, revertir ni fer-hi canvis addicionals. Només es pot visualitzar o suprimir.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Aquesta publicació es va crear en una versió anterior de Liferay. No es pot revertir.
 this-question-is-closed-new-answers-and-comments-are-disabled=Aquesta pregunta està tancada. Les respostes i els comentaris nous estan desactivats.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=Aquesta classificació ja no és aplicable a les cerques perquè el pla a què estava associada s'ha suprimit.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Denne publikation findes ikke længere. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Denne publikation blev oprettet på en tidligere Liferay version. Du kan ikke udgive, gendanne eller foretage yderligere ændringer. Du kan kun få vist eller slette den. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Denne publikation blev oprettet på en tidligere Liferay version. Du kan ikke vende tilbage. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Dette spørgsmål er afsluttet. Nye svar og kommentarer er deaktiveret. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -19359,7 +19359,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=Diese Publikation enthält nicht genehmigte Änderungen.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=Diese Publikation enthält ungenehmigte Änderungen, die vor der Veröffentlichung manuell genehmigt werden müssen.
 this-publication-no-longer-exists=Diese Publikation existiert nicht mehr.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Diese Publikation wurde mit einer früheren Liferay-Version erstellt. Sie können sie nicht veröffentlichen, rückgängig machen oder zusätzliche Änderungen vornehmen. Sie können sie nur anzeigen oder löschen.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Diese Publikation wurde mit einer früheren Liferay-Version erstellt. Sie können sie nicht rückgängig machen.
 this-question-is-closed-new-answers-and-comments-are-disabled=Diese Frage wurde geschlossen. Neue Antworten und Kommentare sind deaktiviert.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=Diese Rangliste kann nicht mehr durchsucht werden, da der Blueprint, mit dem sie verknüpft war, gelöscht wurde.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Αυτή η δημοσίευση δεν υπάρχει πλέον. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Αυτή η έκδοση δημιουργήθηκε σε προηγούμενη έκδοση liferay. Δεν μπορείτε να δημοσιεύσετε, να επιστρέψετε ή να κάνετε πρόσθετες αλλαγές. Μπορείτε να το προβάλετε ή να το διαγράψετε μόνο. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Αυτή η έκδοση δημιουργήθηκε σε προηγούμενη έκδοση liferay. Δεν μπορείς να το επιστρέψεις. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Αυτή η ερώτηση έκλεισε. Οι νέες απαντήσεις και σχόλια απενεργοποιούνται. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -19363,7 +19363,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing.
 this-publication-no-longer-exists=This publication no longer exists.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication.
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it.
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -19359,7 +19359,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=Esta publicación contiene cambios sin aprobar.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=Esta publicación contiene cambios no aprobados que deben aprobarse.
 this-publication-no-longer-exists=Esta publicación ya no existe.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Esta publicación se creó en una versión anterior de Liferay. No se puede publicar, revertir ni realizar cambios adicionales. Solo se puede visualizar o eliminar.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Esta publicación se creó en una versión anterior de Liferay. No se puede revertir.
 this-question-is-closed-new-answers-and-comments-are-disabled=Esta pregunta se ha cerrado. Se han deshabilitado las nuevas respuestas y comentarios.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=Este ranking ya no se puede aplicar a las búsquedas porque el plano al que estaba asociado se ha eliminado.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -19359,7 +19359,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=Esta publicación contiene cambios no aprobados que deben aprobarse.
 this-publication-no-longer-exists=Esta publicación ya no existe.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Esta publicación se creó en una versión anterior de Liferay. No se puede publicar, revertir ni realizar cambios adicionales. Solo se puede visualizar o eliminar.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Esta publicación se creó en una versión anterior de Liferay. No se puede revertir.
 this-question-is-closed-new-answers-and-comments-are-disabled=Esta pregunta se ha cerrado. Se han deshabilitado las nuevas respuestas y comentarios.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -19359,7 +19359,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=Esta publicación contiene cambios no aprobados que deben aprobarse.
 this-publication-no-longer-exists=Esta publicación ya no existe.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Esta publicación se creó en una versión anterior de Liferay. No se puede publicar, revertir ni realizar cambios adicionales. Solo se puede visualizar o eliminar.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Esta publicación se creó en una versión anterior de Liferay. No se puede revertir.
 this-question-is-closed-new-answers-and-comments-are-disabled=Esta pregunta se ha cerrado. Se han deshabilitado las nuevas respuestas y comentarios.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -19359,7 +19359,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=Esta publicación contiene cambios no aprobados que deben aprobarse.
 this-publication-no-longer-exists=Esta publicación ya no existe.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Esta publicación se creó en una versión anterior de Liferay. No se puede publicar, revertir ni realizar cambios adicionales. Solo se puede visualizar o eliminar.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Esta publicación se creó en una versión anterior de Liferay. No se puede revertir.
 this-question-is-closed-new-answers-and-comments-are-disabled=Esta pregunta se ha cerrado. Se han deshabilitado las nuevas respuestas y comentarios.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Seda publikatsiooni pole enam olemas. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=See väljaanne on loodud eelmises Liferay versioonis. Täiendavaid muudatusi ei saa avaldada, ennistada ega teha. Saate seda ainult vaadata või kustutada. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=See väljaanne on loodud eelmises Liferay versioonis. Sa ei saa seda tagasi pöörata. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=See küsimus on lõpetatud. Uued vastused ja kommentaarid on keelatud. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=این نشریه دیگر وجود ندارد. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=این نشریه بر روی نسخه قبلی Liferay ایجاد شده است. شما نمی توانید تغییرات اضافی را منتشر کنید، برنورید یا ایجاد کنید. شما فقط می توانید آن را مشاهده کنید یا حذف کنید. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=این نشریه بر روی نسخه قبلی Liferay ایجاد شده است. تو نميتوني اونو برنداري . (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=این سوال بسته است. پاسخ ها و نظرات جدید از کار افتاده است. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -19355,7 +19355,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=Tämä julkaisu sisältää hyväksymättömiä muutoksia.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=Tämä julkaisu sisältää hyväksymättömiä muutoksia, jotka täytyy hyväksyä ennen julkaisua.
 this-publication-no-longer-exists=Tätä julkaisua ei ole enää olemassa.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Tämä julkaisu luotiin aiemmalla Liferay-versiolla. Et voi julkaista, palata tai tehdä lisämuutoksia. Voit vain katsetlla tai poistaa sen.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Tämä julkaisu luotiin aiemmalla Liferay-versiolla. Et voi palauttaa sitä.
 this-question-is-closed-new-answers-and-comments-are-disabled=Tämä kysymys on suljettu. Uudet vastaukset ja kommentit ovat pois käytöstä.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=Tämä luokittelu ei ole enää käytettävissä hakuihin, koska blueprint-suunnitelma, johon se liittyi, poistettiin.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -19359,7 +19359,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=Cette publication contient des modifications non approuvées.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=Cette publication contient des modifications non approuvées qui doivent être approuvées avant la publication.
 this-publication-no-longer-exists=Cette publication n'existe plus.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Cette publication a été créée sur une version précédente de Liferay. Vous ne pouvez pas publier, rétablir ou apporter des modifications supplémentaires. Vous pouvez uniquement l'afficher ou la supprimer.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Cette publication a été créée sur une version précédente de Liferay. Vous ne pouvez pas la rétablir.
 this-question-is-closed-new-answers-and-comments-are-disabled=Cette question est close. Les nouvelles réponses et commentaires sont désactivés.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=Ce classement n'est plus applicable aux recherches, car le plan auquel il était associé a été supprimé.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Cette publication n'existe plus.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Cette publication a été créée sur une version précédente de Liferay. Vous ne pouvez pas publier, rétablir ou apporter des modifications supplémentaires. Vous pouvez uniquement l'afficher ou la supprimer.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Cette publication a été créée sur une version précédente de Liferay. Vous ne pouvez pas la rétablir.
 this-question-is-closed-new-answers-and-comments-are-disabled=Cette question est close. Les nouvelles réponses et commentaires sont désactivés.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -3583,7 +3583,7 @@ clean-up-orphaned-theme-portlet-preferences=Clean up orphaned theme portlet pref
 clean-up-orphaned-theme-portlet-preferences-help=This process removes all orphaned portlet preferences added by themes. (Automatic Copy)
 clean-up-password-generator-module-data=Clean up password generator module data. (Automatic Copy)
 clean-up-permissions=Clean up permissions. (Automatic Copy)
-clean-up-permissions-help=Este proceso elimina a asignación dalgúns permisos sobre os roles de hóspedes, usuario e potencia do usuario para simplificar a xestión de  páxinas personalizables de usuario . Destacable,  Engadir aos permisos de páxina  elimínase do hóspede e o papel de usuario para todas as aplicacións. Do mesmo xeito, o mesmo permiso redúcese en alcance para os usuarios de enerxía desde o portal de ancho a alcance ata  sitio persoal de usuario .
+clean-up-permissions-help=Este proceso elimina a asignación dalgúns permisos sobre os roles de hóspedes, usuario e potencia do usuario para simplificar a xestión de páxinas personalizables de usuario . Destacable, Engadir aos permisos de páxina elimínase do hóspede e o papel de usuario para todas as aplicacións. Do mesmo xeito, o mesmo permiso redúcese en alcance para os usuarios de enerxía desde o portal de ancho a alcance ata sitio persoal de usuario .
 clean-up-portal-security-wedeploy-auth-module-data=Clean up portal security wedeploy auth module data. (Automatic Copy)
 clean-up-private-messaging-module-data=Clean up private messaging module data. (Automatic Copy)
 clean-up-quick-note-module-data=Clean up quick note module data. (Automatic Copy)
@@ -19345,7 +19345,7 @@ this-parent-item-does-not-belong-to-the-user-but-contains-children-items-belongi
 this-portlet-could-not-be-found.-please-redeploy-it-or-remove-it-from-the-page=This portlet could not be found. Please redeploy it or remove it from the page. (Automatic Copy)
 this-portlet-is-inactive=Este portlet está inactivo.
 this-portlet-is-not-staged-local-alert=A información de este portlet non está en fases. Calquera información modificada estará inmediatamente dispoñible para o sitio <em>Live local</em>. O fluxo de traballo do portlet é respetado. A configuración do portlet está administrada desde o entorno de fases.
-this-portlet-is-not-staged-remote-alert=Os datos deste portlet non se escenifican. Dado que se está a usar a escenificación remota actualmente, os cambios de datos deben realizarse a partir do sitio  remoto en directo . O fluxo de traballo do portlet só ten efecto no sitio  remoto en directo . Ignoraranse todos os cambios de datos a este portlet na posta en escena. A configuración de Portlet aínda se xestiona desde a posta en escena.
+this-portlet-is-not-staged-remote-alert=Os datos deste portlet non se escenifican. Dado que se está a usar a escenificación remota actualmente, os cambios de datos deben realizarse a partir do sitio remoto en directo . O fluxo de traballo do portlet só ten efecto no sitio remoto en directo . Ignoraranse todos os cambios de datos a este portlet na posta en escena. A configuración de Portlet aínda se xestiona desde a posta en escena.
 this-process-may-take-a-while=This process may take a while. (Automatic Copy)
 this-product-does-not-have-any-released-versions=Este produto non ten ningunha versión dispoñible.
 this-product-is-discontinued.-you-can-see-the-replacement-product-by-clicking-on-the-button-below=This product is discontinued. You can see the replacement product by clicking on the button below. (Automatic Copy)
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=यह प्रकाशन अब मौजूद नहीं है। (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=यह प्रकाशन पिछले लाइफ़रे संस्करण पर बनाया गया था। आप अतिरिक्त परिवर्तन नहीं कर सकते, न ही वापस कर सकते हैं और न ही बदल सकते हैं। आप इसे केवल देख सकते हैं या हटा सकते हैं।
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=यह प्रकाशन पिछले लाइफ़रे संस्करण पर बनाया गया था। आप इसे वापस नहीं ला सकते।
 this-question-is-closed-new-answers-and-comments-are-disabled=यह सवाल बंद है। नए जवाब और टिप्पणियां अक्षम हैं । (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -19360,7 +19360,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=Ez a publikáció nem jóváhagyott módosításokat tartalmaz.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=A publikáció nem jóváhagyott változtatásokat tartalmaz, amelyeket a publikálás előtt jóvá kell hagyni.
 this-publication-no-longer-exists=Ez a publikáció már nem létezik.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Ez a publikáció a Liferay egy korábbi verziójában készült. Nem teheti közzé, nem állíthatja vissza, és nem végezhet benne további változásokat. Csak megjelenítheti vagy törölheti.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Ez a publikáció a Liferay egy korábbi verziójában készült. Nem állíthatja vissza.
 this-question-is-closed-new-answers-and-comments-are-disabled=A kérdés lezárva. Az új válaszok és hozzászólások le vannak tiltva.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=A rangsor már nem alkalmazható a keresésekre, mivel a hozzárendelt tervrajzot törölték.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Publikasi ini tidak ada lagi. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Publikasi ini dibuat pada versi Liferay sebelumnya. Anda tidak bisa menerbitkan, mengembalikan, atau membuat perubahan tambahan. Anda hanya bisa melihat atau menghapusnya. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Publikasi ini dibuat pada versi Liferay sebelumnya. Kau tak bisa mengembalikannya. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Pertanyaan ini ditutup. Jawaban dan komentar baru dinonaktifkan. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -19358,7 +19358,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=La presente pubblicazione non esiste più. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Questa pubblicazione è stata creata su una precedente versione di Liferay. Non è possibile pubblicare, ripristinare o apportare modifiche aggiuntive. È possibile visualizzarlo o eliminarlo solo. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Questa pubblicazione è stata creata su una precedente versione di Liferay. Non si può tornare indietro. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=La questione è chiusa. Le nuove risposte e commenti sono disabilitati. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=פרסום זה אינו קיים עוד. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=פרסום זה נוצר בגירסת Liferay קודמת. אין באפשרותך לפרסם, לחזור או לבצע שינויים נוספים. באפשרותך רק להציג או למחוק אותו. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=פרסום זה נוצר בגירסת Liferay קודמת. אתה לא יכול להחזיר אותו. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=שאלה זו סגורה. תשובות והערות חדשות אינן זמינות. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -19359,7 +19359,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=この公開には未承認の変更が含まれています。
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=この公開には未承認の変更が含まれており、公開前に承認する必要があります。
 this-publication-no-longer-exists=この公開はもう存在しません。
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=この公開は旧バージョンのLiferayで作成されました。公開や復元、追加の変更を行うことはできません。表示または削除のみ可能です。
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=この公開は旧バージョンのLiferayで作成されました。復元することはできません。
 this-question-is-closed-new-answers-and-comments-are-disabled=この質問は締め切られています。新しい回答とコメントは無効です。
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=このランキングはそれが関連していたブループリントが削除されたため、もう検索には適用されません。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -19363,7 +19363,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing.
 this-publication-no-longer-exists=This publication no longer exists.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it.
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -19356,7 +19356,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=이 간행물은 더 이상 존재하지 않습니다.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=이 간행물은 이전 Liferay 버전에서 작성되었습니다. 게시하거나 되돌리거나 추가로 변경할 수 없습니다. 보거나 삭제할 수만 있습니다.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=이 간행물은 이전 Liferay 버전에서 작성되었습니다. 되돌릴 수 없습니다.
 this-question-is-closed-new-answers-and-comments-are-disabled=이 질문은 종료되었습니다. 새 답변과 댓글이 비활성화됩니다.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Šio leidinio nebėra. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Šis leidinys buvo sukurtas naudojant ankstesnę "Liferay" versiją. Negalite publikuoti, grąžinti ar atlikti papildomų pakeitimų. Galite tik jį peržiūrėti arba panaikinti. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Šis leidinys buvo sukurtas naudojant ankstesnę "Liferay" versiją. Negalite jo grąžinti. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Šis klausimas baigtas. Nauji atsakymai ir komentarai išjungti. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Penerbitan ini tidak lagi wujud. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Penerbitan ini dicipta pada versi Liferay terdahulu. Anda tidak boleh menerbitkan, kembali, atau membuat perubahan tambahan. Anda hanya boleh melihat atau menghapuskannya. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Penerbitan ini dicipta pada versi Liferay terdahulu. Anda tidak boleh kembali. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Soalan ini ditutup. Jawapan dan komen baru dinyahdayakan. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Denne publikasjonen finnes ikke lenger. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Denne publikasjonen ble opprettet på en tidligere Liferay-versjon. Du kan ikke publisere, tilbakestille eller gjøre flere endringer. Du kan bare vise eller slette den. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Denne publikasjonen ble opprettet på en tidligere Liferay-versjon. Du kan ikke tilbakestille den. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Dette spørsmålet er lukket. Nye svar og kommentarer er deaktivert. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -19360,7 +19360,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=Deze publicatie bevat niet-goedgekeurde wijzigingen.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=Deze publicatie bevat niet-goedgekeurde wijzigingen die moeten worden goedgekeurd voorafgaand aan de publicatie.
 this-publication-no-longer-exists=Deze publicatie bestaat niet meer.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Deze publicatie is gemaakt op een vorige versie van Liferay. U kunt ze niet meer publiceren, herstellen of wijzigen. U kunt de publicatie alleen bekijken of verwijderen.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Deze publicatie is gemaakt op een vorige versie van Liferay. U kunt ze niet herstellen.
 this-question-is-closed-new-answers-and-comments-are-disabled=Deze vraag is afgesloten. Nieuwe antwoorden en commentaar zijn uitgeschakeld.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=Deze rangschikking is niet langer van toepassing op zoekopdrachten omdat de blauwdruk waaraan deze gekoppeld was, verwijderd is.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -19360,7 +19360,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Ta publikacja już nie istnieje. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Niniejsza publikacja została stworzona na poprzedniej wersji Liferay. Nie można publikować, odwracać ani wprowadzać dodatkowych zmian. Można go tylko wyświetlać lub usuwać. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Niniejsza publikacja została stworzona na poprzedniej wersji Liferay. Nie można go przywrócić. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=To pytanie jest zamknięte. Nowe odpowiedzi i komentarze są wyłączone. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=Esta publicação contém alterações não aprovadas.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=Esta publicação contém alterações não aprovadas que devem ser aprovadas antes de serem publicadas.
 this-publication-no-longer-exists=Esta publicação não existe mais.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Esta publicação foi criada em uma versão anterior do Liferay. Ela não pode ser publicada, revertida ou modificada. Só é possível visualizar ou excluir.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Esta publicação foi criada em uma versão anterior do Liferay. Não é possível revertê-la.
 this-question-is-closed-new-answers-and-comments-are-disabled=Esta pergunta foi fechada. Agora as respostas e comentários foram desativados.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=Esta classificação não é mais aplicável a pesquisas porque o esquema ao qual estava associado foi excluído.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -19359,7 +19359,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Esta publicação não existe mais. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Esta publicação foi criada em uma versão anterior do Liferay. Você não pode publicar, reverter ou fazer alterações adicionais. Você só pode visualizá-lo ou excluí-lo. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Esta publicação foi criada em uma versão anterior do Liferay. Você não pode revertê-lo. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Esta pergunta está encerrada. Novas respostas e comentários são desativados. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Această publicație nu mai există. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Această publicație a fost creată pe o versiune Liferay anterioară. Nu aveți posibilitatea să publicați, să reveniți sau să efectuați modificări suplimentare. Aveți posibilitatea să îl vizualizați sau să îl ștergeți numai. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Această publicație a fost creată pe o versiune Liferay anterioară. Nu-l poți întoarce. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Această întrebare este închisă. Răspunsurile și comentariile noi sunt dezactivate. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Эта публикация больше не существует. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Эта публикация была создана на предыдущей версии Liferay. Вы не можете публиковать, возвращаться или вносить дополнительные изменения. Его можно просматривать или удалять только. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Эта публикация была создана на предыдущей версии Liferay. Вы не можете вернуть его. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Этот вопрос закрыт. Новые ответы и комментарии отключены. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Táto publikácia už neexistuje. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Táto publikácia bola vytvorená v predchádzajúcej verzii liferay. Nemôžete publikovať, vrátiť ani vykonať ďalšie zmeny. Môžete ho len zobraziť alebo odstrániť. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Táto publikácia bola vytvorená v predchádzajúcej verzii liferay. Nemôžete ho vrátiť. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Táto otázka je uzavretá. Nové odpovede a komentáre sú vypnuté. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Ta publikacija ne obstaja več. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Ta publikacija je bila ustvarjena v prejšnji različici liferaya. Dodatnih sprememb ne morete objaviti, spremeniti ali spremeniti. Lahko si ga ogledate ali izbrišete le. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Ta publikacija je bila ustvarjena v prejšnji različici liferaya. Ne moreš ga ovrniti. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=To vprašanje je zaključeno. Novi odgovori in komentarji so onemogočeni. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=Den här publiceringen innehåller ändringar som inte godkänts.
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=Den här publiceringen innehåller ändringar som inte godkänts som måste godkännas innan publicering.
 this-publication-no-longer-exists=Den här publiceringen finns inte längre.
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Den här publikationen skapades i en tidigare Liferay-version. Du kan inte publicera, återställa eller göra andra ändringar. Du kan bara se eller radera den.
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Den här publikationen skapades i en tidigare Liferay-version. Du kan inte återställa den.
 this-question-is-closed-new-answers-and-comments-are-disabled=Den här frågan är stängd. Nya svar och kommentarer är inaktiverade.
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=Rankningen är inte längre applicerbar i sökningar eftersom skissen som den är associerad med har tagits bort.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=This publication no longer exists. (Automatic Copy)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view or delete it. (Automatic Copy)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=This publication was created on a previous Liferay version. You cannot revert it. (Automatic Copy)
 this-question-is-closed-new-answers-and-comments-are-disabled=This question is closed. New answers and comments are disabled. (Automatic Copy)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=การเผยแพร่นี้ไม่มีแล้ว
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=การเผยแพร่นี้ถูกสร้างขึ้นบน Liferay เวอร์ชั่นก่อนหน้า คุณไม่สามารถเผยแพร่, ย้อนกลับ, หรือทำการเปลี่ยนแปลงเพิ่มเติมได้ คุณทำได้แค่ดูหรือลบเท่านั้น
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=การเผยแพร่นี้ถูกสร้างขึ้นบน Liferay เวอร์ชั่นก่อนหน้า คุณไม่สามารถย้อนกลับมันได้
 this-question-is-closed-new-answers-and-comments-are-disabled=คำถามนี้ถูกปิด คำตอบและคอมเมนท์ใหม่ถูกปิดใช้งาน
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Bu yayın artık yok. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Bu yayın önceki bir Liferay sürümünde oluşturulmuştur. Yayımlayamaz, geri döndüremez veya ek değişiklikler yapamazsınız. Yalnızca görüntüleyebilir veya silebilirsiniz. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Bu yayın önceki bir Liferay sürümünde oluşturulmuştur. Onu geri çeviremezsin. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Bu soru kapandı. Yeni yanıtlar ve yorumlar devre dışı bırakılır. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Ця публікація більше не існує. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Ця публікація була створена на попередній версії Liferay. Не можна публікувати, повертати або вносити додаткові зміни. Його можна лише переглянути або видалити. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Ця публікація була створена на попередній версії Liferay. Ви не можете повернути його. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Це питання закрите. Нові відповіді та коментарі відключені. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -19357,7 +19357,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=Ấn phẩm này không còn tồn tại. (Automatic Translation)
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=Ấn phẩm này được tạo ra trên phiên bản Liferay trước đó. Bạn không thể phát hành, hoàn nguyên hoặc thực hiện các thay đổi bổ sung. Bạn chỉ có thể xem hoặc xóa nó. (Automatic Translation)
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=Ấn phẩm này được tạo ra trên phiên bản Liferay trước đó. Bạn không thể hoàn nguyên nó. (Automatic Translation)
 this-question-is-closed-new-answers-and-comments-are-disabled=Câu hỏi này đã được đóng lại. Câu trả lời và nhận xét mới bị vô hiệu hóa. (Automatic Translation)
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -19359,7 +19359,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=此发布中包含未获批准的更改。
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=此发布包含未获批准的更改，必须批准这些更改后才能发布。
 this-publication-no-longer-exists=此发布不再存在。
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=此发布是在之前的 Liferay 版本上创建的。您无法发布、还原或进行其他更改，只能进行查看或删除操作。
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=此发布是在之前的 Liferay 版本上创建的。您无法还原它。
 this-question-is-closed-new-answers-and-comments-are-disabled=此问题已关闭。新回答和评论已禁用。
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=此排名不再适用于搜索，因为与之关联的蓝图已被删除。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -19358,7 +19358,7 @@ this-publication-contains-conflicting-changes-that-must-be-manually-resolved-bef
 this-publication-contains-unapproved-changes=This publication contains unapproved changes. (Automatic Copy)
 this-publication-contains-unapproved-changes-that-must-be-approved-before-publishing=This publication contains unapproved changes that must be approved before publishing. (Automatic Copy)
 this-publication-no-longer-exists=此發布不再存在。
-this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=此項發布，由於已被之前 Liferay 版本所建立，無法再發布、撤回或做其他變更，只能檢視或刪除。
+this-publication-was-created-on-a-previous-liferay-version.-you-cannot-publish,-revert,-or-make-additional-changes=This publication was created on a previous Liferay version. You cannot publish, revert, or make additional changes. You can only view, delete it or move its changes to another publication. (Automatic Copy)
 this-publication-was-created-on-a-previous-liferay-version.-you-cannot-revert-it=此項發布已被之前的 Liferay 版本所建立，無法撤回。
 this-question-is-closed-new-answers-and-comments-are-disabled=此問題已關閉。新回答和評論已停用。
 this-ranking-is-no-longer-applicable-to-searches-because-the-blueprint-it-was-associated-with-was-deleted=This ranking is no longer applicable to searches because the blueprint it was associated with was deleted. (Automatic Copy)


### PR DESCRIPTION
This is an update for: [LPD-20140](https://liferay.atlassian.net/browse/LPD-20140)

Now out of date publications can have its changes moved to another publication 
![image](https://github.com/liferay-publications/liferay-portal/assets/48836305/33caaa10-f99b-46f6-a945-0a016cd5837f)

