### PR TITLE
LPD-27013 Don't show the assign button when workflow task is complete

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
@@ -1059,9 +1059,7 @@ public class GetEntryRenderDataMVCResourceCommand
 
 		WorkflowTask workflowTask = _getWorkflowTask(ctEntry, model);
 
-		if ((workflowTask == null) ||
-			!Objects.equals(workflowTask.getName(), "review")) {
-
+		if ((workflowTask == null) || workflowTask.isCompleted()) {
 			return null;
 		}
 
@@ -1187,7 +1185,10 @@ public class GetEntryRenderDataMVCResourceCommand
 			).put(
 				"assignButton",
 				() -> {
-					if (currentCTCollectionId != ctEntry.getCtCollectionId()) {
+					if ((currentCTCollectionId !=
+							ctEntry.getCtCollectionId()) ||
+						workflowTask.isCompleted()) {
+
 						return null;
 					}
 


### PR DESCRIPTION
Based on the behavior in the workflow portlet, we should be able to assign a task when it's rejected. 
I applied this fix for when a task is approved and completed.