### PR TITLE
LPD-23430 Add workflow transition actions to the dropdown menu

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
@@ -75,6 +75,8 @@ import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowLog;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
+import com.liferay.portal.kernel.workflow.WorkflowTaskManagerUtil;
+import com.liferay.portal.kernel.workflow.WorkflowTransition;
 import com.liferay.portal.workflow.comparator.WorkflowComparatorFactory;
 import com.liferay.portal.workflow.manager.WorkflowLogManager;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
@@ -1062,16 +1064,16 @@ public class GetEntryRenderDataMVCResourceCommand
 
 		WorkflowTask workflowTask = _getWorkflowTask(ctEntry, model);
 
-		if ((workflowTask == null) || workflowTask.isCompleted()) {
+		if (workflowTask == null) {
 			return null;
 		}
 
 		JSONArray jsonArray = _jsonFactory.createJSONArray();
 
-		if ((workflowTask.getAssigneeUserId() == -1) ||
-			!Objects.equals(
-				workflowTask.getAssigneeUserId(), themeDisplay.getUserId())) {
+		boolean assignedToUserId = Objects.equals(
+			workflowTask.getAssigneeUserId(), themeDisplay.getUserId());
 
+		if ((workflowTask.getAssigneeUserId() == -1) || !assignedToUserId) {
 			jsonArray = jsonArray.put(
 				JSONUtil.put(
 					"href",
@@ -1085,6 +1087,8 @@ public class GetEntryRenderDataMVCResourceCommand
 					).setParameter(
 						"assignMode", "assignToMe"
 					).setParameter(
+						"hideDefaultSuccessMessage", "true"
+					).setParameter(
 						"workflowTaskId", workflowTask.getWorkflowTaskId()
 					).setWindowState(
 						LiferayWindowState.POP_UP
@@ -1097,29 +1101,67 @@ public class GetEntryRenderDataMVCResourceCommand
 				));
 		}
 
-		return jsonArray.put(
-			JSONUtil.put(
-				"href",
-				PortletURLBuilder.createRenderURL(
-					_portal.getLiferayPortletResponse(resourceResponse),
-					PortletKeys.MY_WORKFLOW_TASK
-				).setMVCPath(
-					"/workflow_task_assign.jsp"
-				).setParameter(
-					"assigneeUserId", -1
-				).setParameter(
-					"assignMode", "assignTo"
-				).setParameter(
-					"workflowTaskId", workflowTask.getWorkflowTaskId()
-				).setWindowState(
-					LiferayWindowState.POP_UP
-				).buildString()
-			).put(
-				"label",
-				_language.get(themeDisplay.getLocale(), "assign-to-...")
-			).put(
-				"modalHeight", "356px"
-			));
+		if (!workflowTask.isCompleted()) {
+			if (assignedToUserId) {
+				for (WorkflowTransition workflowTransition :
+						WorkflowTaskManagerUtil.
+							getWorkflowTaskWorkflowTransitions(
+								workflowTask.getWorkflowTaskId())) {
+
+					jsonArray = jsonArray.put(
+						JSONUtil.put(
+							"href",
+							PortletURLBuilder.createActionURL(
+								_portal.getLiferayPortletResponse(
+									resourceResponse),
+								PortletKeys.MY_WORKFLOW_TASK
+							).setActionName(
+								"/portal_workflow_task/complete_task"
+							).setRedirect(
+								themeDisplay.getURLCurrent()
+							).setParameter(
+								"assigneeUserId",
+								workflowTask.getAssigneeUserId()
+							).setParameter(
+								"workflowTaskId",
+								workflowTask.getWorkflowTaskId()
+							).buildString()
+						).put(
+							"label",
+							workflowTransition.getLabel(
+								themeDisplay.getLocale())
+						));
+				}
+			}
+
+			jsonArray.put(
+				JSONUtil.put(
+					"href",
+					PortletURLBuilder.createRenderURL(
+						_portal.getLiferayPortletResponse(resourceResponse),
+						PortletKeys.MY_WORKFLOW_TASK
+					).setMVCPath(
+						"/workflow_task_assign.jsp"
+					).setParameter(
+						"assigneeUserId", -1
+					).setParameter(
+						"assignMode", "assignTo"
+					).setParameter(
+						"hideDefaultSuccessMessage", "true"
+					).setParameter(
+						"workflowTaskId", workflowTask.getWorkflowTaskId()
+					).setWindowState(
+						LiferayWindowState.POP_UP
+					).buildString()
+				).put(
+					"label",
+					_language.get(themeDisplay.getLocale(), "assign-to-...")
+				).put(
+					"modalHeight", "356px"
+				));
+		}
+
+		return jsonArray;
 	}
 
 	private <T extends BaseModel<T>> JSONObject _getWorkflowDataJSONObject(

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java
@@ -1101,65 +1101,60 @@ public class GetEntryRenderDataMVCResourceCommand
 				));
 		}
 
-		if (!workflowTask.isCompleted()) {
-			if (assignedToUserId) {
-				for (WorkflowTransition workflowTransition :
-						WorkflowTaskManagerUtil.
-							getWorkflowTaskWorkflowTransitions(
-								workflowTask.getWorkflowTaskId())) {
+		if (assignedToUserId) {
+			for (WorkflowTransition workflowTransition :
+					WorkflowTaskManagerUtil.getWorkflowTaskWorkflowTransitions(
+						workflowTask.getWorkflowTaskId())) {
 
-					jsonArray = jsonArray.put(
-						JSONUtil.put(
-							"href",
-							PortletURLBuilder.createActionURL(
-								_portal.getLiferayPortletResponse(
-									resourceResponse),
-								PortletKeys.MY_WORKFLOW_TASK
-							).setActionName(
-								"/portal_workflow_task/complete_task"
-							).setRedirect(
-								themeDisplay.getURLCurrent()
-							).setParameter(
-								"assigneeUserId",
-								workflowTask.getAssigneeUserId()
-							).setParameter(
-								"workflowTaskId",
-								workflowTask.getWorkflowTaskId()
-							).buildString()
-						).put(
-							"label",
-							workflowTransition.getLabel(
-								themeDisplay.getLocale())
-						));
-				}
+				jsonArray = jsonArray.put(
+					JSONUtil.put(
+						"href",
+						PortletURLBuilder.createActionURL(
+							_portal.getLiferayPortletResponse(resourceResponse),
+							PortletKeys.MY_WORKFLOW_TASK
+						).setActionName(
+							"/portal_workflow_task/complete_task"
+						).setRedirect(
+							themeDisplay.getURLCurrent()
+						).setParameter(
+							"assigneeUserId", workflowTask.getAssigneeUserId()
+						).setParameter(
+							"transitionName", workflowTransition.getName()
+						).setParameter(
+							"workflowTaskId", workflowTask.getWorkflowTaskId()
+						).buildString()
+					).put(
+						"label",
+						workflowTransition.getLabel(themeDisplay.getLocale())
+					));
 			}
-
-			jsonArray.put(
-				JSONUtil.put(
-					"href",
-					PortletURLBuilder.createRenderURL(
-						_portal.getLiferayPortletResponse(resourceResponse),
-						PortletKeys.MY_WORKFLOW_TASK
-					).setMVCPath(
-						"/workflow_task_assign.jsp"
-					).setParameter(
-						"assigneeUserId", -1
-					).setParameter(
-						"assignMode", "assignTo"
-					).setParameter(
-						"hideDefaultSuccessMessage", "true"
-					).setParameter(
-						"workflowTaskId", workflowTask.getWorkflowTaskId()
-					).setWindowState(
-						LiferayWindowState.POP_UP
-					).buildString()
-				).put(
-					"label",
-					_language.get(themeDisplay.getLocale(), "assign-to-...")
-				).put(
-					"modalHeight", "356px"
-				));
 		}
+
+		jsonArray.put(
+			JSONUtil.put(
+				"href",
+				PortletURLBuilder.createRenderURL(
+					_portal.getLiferayPortletResponse(resourceResponse),
+					PortletKeys.MY_WORKFLOW_TASK
+				).setMVCPath(
+					"/workflow_task_assign.jsp"
+				).setParameter(
+					"assigneeUserId", -1
+				).setParameter(
+					"assignMode", "assignTo"
+				).setParameter(
+					"hideDefaultSuccessMessage", "true"
+				).setParameter(
+					"workflowTaskId", workflowTask.getWorkflowTaskId()
+				).setWindowState(
+					LiferayWindowState.POP_UP
+				).buildString()
+			).put(
+				"label",
+				_language.get(themeDisplay.getLocale(), "assign-to-...")
+			).put(
+				"modalHeight", "356px"
+			));
 
 		return jsonArray;
 	}
@@ -1191,7 +1186,8 @@ public class GetEntryRenderDataMVCResourceCommand
 			WorkflowInstanceLink workflowInstanceLink =
 				_getWorkflowInstanceLink(ctEntry, model);
 
-			WorkflowTask workflowTask = _getWorkflowTask(workflowInstanceLink);
+			WorkflowTask workflowTask = _getWorkflowTask(
+				workflowInstanceLink, null);
 
 			if (workflowTask == null) {
 				return null;
@@ -1544,11 +1540,12 @@ public class GetEntryRenderDataMVCResourceCommand
 			CTEntry ctEntry, T model)
 		throws Exception {
 
-		return _getWorkflowTask(_getWorkflowInstanceLink(ctEntry, model));
+		return _getWorkflowTask(
+			_getWorkflowInstanceLink(ctEntry, model), false);
 	}
 
 	private WorkflowTask _getWorkflowTask(
-			WorkflowInstanceLink workflowInstanceLink)
+			WorkflowInstanceLink workflowInstanceLink, Boolean completed)
 		throws Exception {
 
 		if (workflowInstanceLink == null) {
@@ -1558,7 +1555,8 @@ public class GetEntryRenderDataMVCResourceCommand
 		List<WorkflowTask> workflowTasks =
 			_workflowTaskManager.getWorkflowTasksByWorkflowInstance(
 				workflowInstanceLink.getCompanyId(), null,
-				workflowInstanceLink.getWorkflowInstanceId(), null, 0, 1, null);
+				workflowInstanceLink.getWorkflowInstanceId(), completed, 0, 1,
+				null);
 
 		if (workflowTasks.isEmpty()) {
 			return null;

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
@@ -20,6 +20,7 @@ import {
 	fetch,
 	navigate as navigateUtil,
 	openConfirmModal,
+	openSimpleInputModal,
 	openToast,
 } from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
@@ -837,17 +838,64 @@ export default function ChangeTrackingRenderView({
 
 		const workflowActionsDropdownItems = [];
 
-		state.renderData.workflowActions?.forEach((workflowAction) => {
-			workflowActionsDropdownItems.push({
-				label: workflowAction.label,
-				onClick: () =>
-					openWorkflowAssignModal(
-						workflowAction.href,
-						workflowAction.label,
-						workflowAction.modalHeight
-					),
-				symbolLeft: 'workflow',
-			});
+		state.renderData.workflowActions?.forEach((workflowAction, i) => {
+			if (workflowAction.modalHeight) {
+				workflowActionsDropdownItems.push({
+					label: workflowAction.label,
+					onClick: () =>
+						Liferay.Util.openModal({
+							center: true,
+							customEvents: [
+								{
+									name: `${namespace}workflowTaskUpdated`,
+									onEvent() {
+										const iframe = document.querySelector(
+											'.liferay-modal iframe'
+										);
+
+										iframe.contentWindow.location.reload();
+
+										setShowWorkflowSuccessMessage(true);
+									},
+								},
+							],
+							height: workflowAction.modalHeight,
+							onOpen: () => setShowWorkflowSuccessMessage(false),
+							size: 'lg',
+							title: workflowAction.label,
+							url: workflowAction.href,
+						}),
+					symbolLeft: 'workflow',
+				});
+			}
+			else {
+				workflowActionsDropdownItems.push({
+					id: `${namespace}${i}taskChangeStatusLink`,
+					label: workflowAction.label,
+					onClick: () => {
+						openSimpleInputModal({
+							buttonSubmitLabel: Liferay.Language.get('done'),
+							center: true,
+							dialogTitle: workflowAction.label,
+							formSubmitURL: workflowAction.href,
+							mainFieldComponent: 'textarea',
+							mainFieldLabel: Liferay.Language.get('comment'),
+							mainFieldName: 'comment',
+							mainFieldPlaceholder:
+								Liferay.Language.get('comment'),
+							namespace,
+							onFormSuccess: () => {
+								setShowWorkflowSuccessMessage(true);
+
+								setTimeout(() => window.location.reload(), 500);
+							},
+							required: false,
+							size: 'lg',
+						});
+					},
+					symbolLeft: 'workflow',
+				});
+			}
 		});
 
 		if (workflowActionsDropdownItems.length) {

--- a/modules/test/playwright/tests/change-tracking-web/viewChangesWorkflow.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/viewChangesWorkflow.spec.ts
@@ -380,6 +380,80 @@ test('LPD-22771 Assign button is not visible in other publications', async ({
 	await expect(assignButton).toBeVisible({visible: false});
 });
 
+test('LPD-23430 Workflow transition actions are displayed in dropdown', async ({
+	changeTrackingPage,
+	ctCollection,
+	page,
+}) => {
+	await changeTrackingPage.goToReviewChanges(ctCollection.name);
+
+	await changeTrackingPage.reviewChange(journalName);
+
+	const moreActionsButton = page.getByLabel('more-actions');
+
+	await moreActionsButton.click();
+
+	const assignToMeMenuItem = page.getByRole('menuitem', {
+		name: 'Assign to me',
+	});
+
+	await assignToMeMenuItem.click();
+
+	await page
+		.frameLocator('iframe[title="Assign to Me"]')
+		.getByRole('button', {exact: true, name: 'Done'})
+		.click();
+
+	await moreActionsButton.click();
+
+	await page.getByRole('menuitem', {name: 'Reject'}).click();
+
+	await expect(page.getByRole('heading', {name: 'Reject'})).toBeVisible();
+
+	const doneButton = page.getByText('Done');
+
+	await doneButton.click();
+
+	await page.reload();
+
+	await expect(
+		page.locator('span').filter({hasText: 'Pending'}).first()
+	).toBeVisible();
+
+	await moreActionsButton.click();
+
+	await page.getByRole('menuitem', {name: 'Resubmit'}).click();
+
+	await expect(page.getByRole('heading', {name: 'Resubmit'})).toBeVisible();
+
+	await doneButton.click();
+
+	await page.reload();
+
+	await moreActionsButton.click();
+
+	await assignToMeMenuItem.click();
+
+	await page
+		.frameLocator('iframe[title="Assign to Me"]')
+		.getByRole('button', {exact: true, name: 'Done'})
+		.click();
+
+	await page.getByRole('cell', {exact: true, name: 'Test Test'});
+
+	await moreActionsButton.click();
+
+	await page.getByRole('menuitem', {name: 'Approve'}).click();
+
+	await expect(page.getByRole('heading', {name: 'Approve'})).toBeVisible();
+
+	await doneButton.click();
+
+	await expect(
+		page.locator('span').filter({hasText: 'Approved'}).first()
+	).toBeVisible();
+});
+
 test('LPD-27013 Cannot assign tasks once task is completed', async ({
 	changeTrackingPage,
 	ctCollection,


### PR DESCRIPTION
Update for: https://liferay.atlassian.net/browse/LPD-23430

The successMessages are not appearing in the modals(when accepting transition actions) due to [this parameter in the request](https://github.com/liferay-publications/liferay-portal/blob/3b0e769bf9693a2727dfb13fa574630259df06d6/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetEntryRenderDataMVCResourceCommand.java#L1086-L1087), if removed they appear back again.
Right now the place they are being shown are on the My Workflow Tasks page, even with the parameter on
![image](https://github.com/liferay-publications/liferay-portal/assets/48836305/33c6ee5c-37a5-4128-872d-5d622de482a2)

The workflow transition tasks and its functions do appear in the dropdown now
![image](https://github.com/liferay-publications/liferay-portal/assets/48836305/149bf75e-e070-4810-b1ab-a120da7f35aa)
![image](https://github.com/liferay-publications/liferay-portal/assets/48836305/d92ac8ff-09a6-4e30-939e-0a8874358615)
