### PR TITLE
LPD-28975 Workflow tab shows unexpected error for asset added in publication and subsequently enabling workflow

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -37,6 +37,7 @@ import com.liferay.frontend.data.set.model.FDSSortItemList;
 import com.liferay.frontend.data.set.model.FDSSortItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
+import com.liferay.knowledge.base.model.KBArticleModel;
 import com.liferay.petra.lang.HashUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.CharPool;
@@ -59,11 +60,13 @@ import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserTable;
+import com.liferay.portal.kernel.model.WorkflowInstanceLink;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -77,6 +80,8 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowTask;
+import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.Serializable;
@@ -120,7 +125,9 @@ public class ViewChangesDisplayContext {
 		GroupLocalService groupLocalService, Language language, Portal portal,
 		PublicationsDisplayContext publicationsDisplayContext,
 		PublishScheduler publishScheduler, RenderRequest renderRequest,
-		RenderResponse renderResponse, UserLocalService userLocalService) {
+		RenderResponse renderResponse, UserLocalService userLocalService,
+		WorkflowInstanceLinkLocalService workflowInstanceLinkLocalService,
+		WorkflowTaskManager workflowTaskManager) {
 
 		_activeCTCollectionId = activeCTCollectionId;
 		_basePersistenceRegistry = basePersistenceRegistry;
@@ -138,6 +145,8 @@ public class ViewChangesDisplayContext {
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 		_userLocalService = userLocalService;
+		_workflowInstanceLinkLocalService = workflowInstanceLinkLocalService;
+		_workflowTaskManager = workflowTaskManager;
 
 		_httpServletRequest = portal.getHttpServletRequest(renderRequest);
 
@@ -1276,6 +1285,36 @@ public class ViewChangesDisplayContext {
 		return false;
 	}
 
+	private <T extends BaseModel<T>> boolean _isWorkflowTasksEmpty(
+			CTEntry ctEntry, long groupId, T model)
+		throws Exception {
+
+		long classPK = ctEntry.getModelClassPK();
+
+		if (model instanceof KBArticleModel) {
+			Map<String, Object> modelAttributes = model.getModelAttributes();
+
+			classPK = GetterUtil.getLong(
+				modelAttributes.get("resourcePrimKey"));
+		}
+
+		WorkflowInstanceLink workflowInstanceLink =
+			_workflowInstanceLinkLocalService.fetchWorkflowInstanceLink(
+				ctEntry.getCompanyId(), groupId,
+				_portal.getClassName(ctEntry.getModelClassNameId()), classPK);
+
+		if (workflowInstanceLink == null) {
+			return true;
+		}
+
+		List<WorkflowTask> workflowTasks =
+			_workflowTaskManager.getWorkflowTasksByWorkflowInstance(
+				workflowInstanceLink.getCompanyId(), null,
+				workflowInstanceLink.getWorkflowInstanceId(), null, 0, 1, null);
+
+		return workflowTasks.isEmpty();
+	}
+
 	private <T extends BaseModel<T>> void _populateEntryValues(
 			Map<ModelInfoKey, ModelInfo> modelInfoMap, long modelClassNameId,
 			Set<Long> classPKs, Map<Long, String> typeNameCacheMap)
@@ -1458,11 +1497,14 @@ public class ViewChangesDisplayContext {
 					"workflowStatus", (Integer)modelAttributes.get("status")
 				);
 
+				long groupId = 0;
+
 				if (model instanceof GroupedModel) {
 					GroupedModel groupedModel = (GroupedModel)model;
 
-					modelInfo._jsonObject.put(
-						"groupId", groupedModel.getGroupId());
+					groupId = groupedModel.getGroupId();
+
+					modelInfo._jsonObject.put("groupId", groupId);
 				}
 
 				if (FeatureFlagManagerUtil.isEnabled("LPD-10703")) {
@@ -1475,7 +1517,9 @@ public class ViewChangesDisplayContext {
 						((Integer)modelAttributes.get("status") !=
 							WorkflowConstants.STATUS_DRAFT)) {
 
-						modelInfo._jsonObject.put("showWorkflow", true);
+						modelInfo._jsonObject.put(
+							"showWorkflow",
+							!_isWorkflowTasksEmpty(ctEntry, groupId, model));
 					}
 				}
 
@@ -1554,6 +1598,9 @@ public class ViewChangesDisplayContext {
 	private Map<String, Object> _toolbarReactData;
 	private final User _user;
 	private final UserLocalService _userLocalService;
+	private final WorkflowInstanceLinkLocalService
+		_workflowInstanceLinkLocalService;
+	private final WorkflowTaskManager _workflowTaskManager;
 
 	private static class ModelInfo {
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -39,10 +39,12 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
 import com.liferay.knowledge.base.model.KBArticleModel;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.change.tracking.sql.CTSQLModeThreadLocal;
 import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -1298,21 +1300,28 @@ public class ViewChangesDisplayContext {
 				modelAttributes.get("resourcePrimKey"));
 		}
 
-		WorkflowInstanceLink workflowInstanceLink =
-			_workflowInstanceLinkLocalService.fetchWorkflowInstanceLink(
-				ctEntry.getCompanyId(), groupId,
-				_portal.getClassName(ctEntry.getModelClassNameId()), classPK);
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctEntry.getCtCollectionId())) {
 
-		if (workflowInstanceLink == null) {
-			return true;
+			WorkflowInstanceLink workflowInstanceLink =
+				_workflowInstanceLinkLocalService.fetchWorkflowInstanceLink(
+					ctEntry.getCompanyId(), groupId,
+					_portal.getClassName(ctEntry.getModelClassNameId()),
+					classPK);
+
+			if (workflowInstanceLink == null) {
+				return true;
+			}
+
+			List<WorkflowTask> workflowTasks =
+				_workflowTaskManager.getWorkflowTasksByWorkflowInstance(
+					workflowInstanceLink.getCompanyId(), null,
+					workflowInstanceLink.getWorkflowInstanceId(), null, 0, 1,
+					null);
+
+			return workflowTasks.isEmpty();
 		}
-
-		List<WorkflowTask> workflowTasks =
-			_workflowTaskManager.getWorkflowTasksByWorkflowInstance(
-				workflowInstanceLink.getCompanyId(), null,
-				workflowInstanceLink.getWorkflowInstanceId(), null, 0, 1, null);
-
-		return workflowTasks.isEmpty();
 	}
 
 	private <T extends BaseModel<T>> void _populateEntryValues(

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -82,6 +82,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowException;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
 import com.liferay.portal.util.PropsValues;
@@ -1273,6 +1274,24 @@ public class ViewChangesDisplayContext {
 		return ctDisplayRenderer.getTypeName(locale);
 	}
 
+	private List<WorkflowTask> _getWorkflowTasks(
+			CTEntry ctEntry, long classPK, long groupId)
+		throws WorkflowException {
+
+		WorkflowInstanceLink workflowInstanceLink =
+			_workflowInstanceLinkLocalService.fetchWorkflowInstanceLink(
+				ctEntry.getCompanyId(), groupId,
+				_portal.getClassName(ctEntry.getModelClassNameId()), classPK);
+
+		if (workflowInstanceLink == null) {
+			return null;
+		}
+
+		return _workflowTaskManager.getWorkflowTasksByWorkflowInstance(
+			workflowInstanceLink.getCompanyId(), null,
+			workflowInstanceLink.getWorkflowInstanceId(), null, 0, 1, null);
+	}
+
 	private <T extends BaseModel<T>> boolean _isSite(T model) {
 		if (model instanceof Group) {
 			Group group = (Group)model;
@@ -1300,27 +1319,34 @@ public class ViewChangesDisplayContext {
 				modelAttributes.get("resourcePrimKey"));
 		}
 
+		CTCollection ctCollection = _ctCollectionLocalService.getCTCollection(
+			ctEntry.getCtCollectionId());
+
+		if (ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED) {
+			List<WorkflowTask> workflowTasks = _getWorkflowTasks(
+				ctEntry, classPK, groupId);
+
+			if (workflowTasks == null) {
+				return true;
+			}
+
+			return !workflowTasks.get(
+				0
+			).isCompleted();
+		}
+
 		try (SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 					ctEntry.getCtCollectionId())) {
 
-			WorkflowInstanceLink workflowInstanceLink =
-				_workflowInstanceLinkLocalService.fetchWorkflowInstanceLink(
-					ctEntry.getCompanyId(), groupId,
-					_portal.getClassName(ctEntry.getModelClassNameId()),
-					classPK);
+			List<WorkflowTask> workflowTasks = _getWorkflowTasks(
+				ctEntry, classPK, groupId);
 
-			if (workflowInstanceLink == null) {
+			if (workflowTasks == null) {
 				return true;
 			}
 
-			List<WorkflowTask> workflowTasks =
-				_workflowTaskManager.getWorkflowTasksByWorkflowInstance(
-					workflowInstanceLink.getCompanyId(), null,
-					workflowInstanceLink.getWorkflowInstanceId(), null, 0, 1,
-					null);
-
-			return workflowTasks.isEmpty();
+			return false;
 		}
 	}
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/ViewChangeMVCRenderCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/ViewChangeMVCRenderCommand.java
@@ -34,11 +34,13 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
 import com.liferay.portlet.LiferayPortletUtil;
 
 import javax.portlet.RenderRequest;
@@ -145,7 +147,8 @@ public class ViewChangeMVCRenderCommand implements MVCRenderCommand {
 					_portal.getHttpServletRequest(renderRequest), _language,
 					_publicationHelper, renderRequest, renderResponse),
 				_publishSchedulerSnapshot.get(), renderRequest, renderResponse,
-				_userLocalService);
+				_userLocalService, _workflowInstanceLinkLocalService,
+				_workflowTaskManager);
 
 		renderRequest.setAttribute(
 			CTWebKeys.VIEW_CHANGES_DISPLAY_CONTEXT, viewChangesDisplayContext);
@@ -205,5 +208,11 @@ public class ViewChangeMVCRenderCommand implements MVCRenderCommand {
 
 	@Reference
 	private UserLocalService _userLocalService;
+
+	@Reference
+	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;
+
+	@Reference
+	private WorkflowTaskManager _workflowTaskManager;
 
 }

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/ViewChangesMVCRenderCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/ViewChangesMVCRenderCommand.java
@@ -32,11 +32,13 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
 
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
@@ -106,7 +108,8 @@ public class ViewChangesMVCRenderCommand implements MVCRenderCommand {
 						httpServletRequest, _language, _publicationHelper,
 						renderRequest, renderResponse),
 					_publishSchedulerSnapshot.get(), renderRequest,
-					renderResponse, _userLocalService);
+					renderResponse, _userLocalService,
+					_workflowInstanceLinkLocalService, _workflowTaskManager);
 
 			renderRequest.setAttribute(
 				CTWebKeys.VIEW_CHANGES_DISPLAY_CONTEXT,
@@ -183,5 +186,11 @@ public class ViewChangesMVCRenderCommand implements MVCRenderCommand {
 
 	@Reference
 	private UserLocalService _userLocalService;
+
+	@Reference
+	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;
+
+	@Reference
+	private WorkflowTaskManager _workflowTaskManager;
 
 }

--- a/modules/test/playwright/tests/change-tracking-web/viewChangesWorkflow.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/viewChangesWorkflow.spec.ts
@@ -11,6 +11,7 @@ import {changeTrackingPagesTest} from '../../fixtures/changeTrackingPagesTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
 import getRandomString from '../../utils/getRandomString';
+import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 
 export const test = mergeTests(
@@ -623,4 +624,51 @@ test('LPD-28734 SuccessMessage appears on Workflow Portlet after doing workflow 
 	await expect(
 		page.locator('#ToastAlertContainer .alert-success').first()
 	).toBeHidden();
+});
+
+test('LPD-28975 Workflow tab shows unexpected error for asset added in publication and subsequently enabling workflow', async ({
+	changeTrackingPage,
+	ctCollection,
+	journalEditArticlePage,
+	page,
+	workflowPage,
+}) => {
+	await changeTrackingPage.workOnProduction();
+
+	await workflowPage.goto();
+
+	await workflowPage.changeWorkflow('Web Content Article', 'No Workflow', {
+		disable: true,
+	});
+
+	await changeTrackingPage.workOnPublication(ctCollection);
+
+	await journalEditArticlePage.goto();
+
+	const title1 = getRandomString();
+
+	await journalEditArticlePage.fillTitle(title1);
+
+	await page.getByRole('button', {name: 'Publish'}).click();
+
+	await waitForSuccessAlert(
+		page,
+		`Success:${title1} was created successfully.`
+	);
+
+	await workflowPage.goto();
+
+	await workflowPage.changeWorkflow('Web Content Article', 'Single Approver');
+
+	await journalEditArticlePage.goto();
+
+	const title2 = getRandomString();
+
+	await journalEditArticlePage.submitArticleForWorkflow(title2);
+
+	await changeTrackingPage.goToReviewChanges(ctCollection.name);
+
+	await changeTrackingPage.reviewChange(title1);
+
+	await changeTrackingPage.viewDisplayTab('Workflow', {isHidden: true});
 });


### PR DESCRIPTION
Update for: [LPD-28975](https://liferay.atlassian.net/browse/LPD-28975)

Now the workflow tab does not appear when viewing a change that was added before workflow were enabled for its entity.

The issue was related to the code only checking if workflow was enabled and not if there were tasks related to the change. 

![image](https://github.com/liferay-publications/liferay-portal/assets/48836305/b786e058-77fb-4efa-938b-6a42ec814faf)
