### PR TITLE
LPD-33486 User remains logged into Intercom session after logging out of Liferay

### DIFF
--- a/modules/apps/click-to-chat/click-to-chat-test/bnd.bnd
+++ b/modules/apps/click-to-chat/click-to-chat-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Click to Chat Test
+Bundle-SymbolicName: com.liferay.click.to.chat.test
+Bundle-Version: 1.0.0

--- a/modules/apps/click-to-chat/click-to-chat-test/build.gradle
+++ b/modules/apps/click-to-chat/click-to-chat-test/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/click-to-chat/click-to-chat-test/src/testIntegration/java/com/liferay/click/to/chat/web/internal/events/test/LogoutPreActionTest.java
+++ b/modules/apps/click-to-chat/click-to-chat-test/src/testIntegration/java/com/liferay/click/to/chat/web/internal/events/test/LogoutPreActionTest.java
@@ -1,0 +1,126 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.click.to.chat.web.internal.events.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.security.auth.session.AuthenticatedSessionManagerUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import javax.servlet.http.Cookie;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Jonathan McCann
+ */
+@RunWith(Arquillian.class)
+public class LogoutPreActionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_setUpMockHttpServletRequest();
+	}
+
+	@Test
+	public void testLogoutWithClickToChatDisabled() throws Exception {
+		_assertCookiesExist();
+
+		AuthenticatedSessionManagerUtil.logout(
+			_mockHttpServletRequest, new MockHttpServletResponse());
+
+		_assertCookiesExist();
+	}
+
+	@Test
+	public void testLogoutWithClickToChatEnabled() throws Exception {
+		_assertCookiesExist();
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					"com.liferay.click.to.chat.web.internal.configuration." +
+						"ClickToChatConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"chatProviderId", "intercom"
+					).put(
+						"enabled", true
+					).build())) {
+
+			AuthenticatedSessionManagerUtil.logout(
+				_mockHttpServletRequest, new MockHttpServletResponse());
+		}
+
+		_assertCookiesDeleted();
+	}
+
+	private void _assertCookiesDeleted() {
+		Assert.assertNull(
+			CookiesManagerUtil.getCookieValue(
+				"intercom-id-test", _mockHttpServletRequest));
+		Assert.assertNull(
+			CookiesManagerUtil.getCookieValue(
+				"intercom-session-test", _mockHttpServletRequest));
+		Assert.assertNotNull(
+			CookiesManagerUtil.getCookieValue(
+				"test-cookie", _mockHttpServletRequest));
+	}
+
+	private void _assertCookiesExist() {
+		Assert.assertNotNull(
+			CookiesManagerUtil.getCookieValue(
+				"intercom-id-test", _mockHttpServletRequest));
+		Assert.assertNotNull(
+			CookiesManagerUtil.getCookieValue(
+				"intercom-session-test", _mockHttpServletRequest));
+		Assert.assertNotNull(
+			CookiesManagerUtil.getCookieValue(
+				"test-cookie", _mockHttpServletRequest));
+	}
+
+	private void _setUpMockHttpServletRequest() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+
+		_mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		_mockHttpServletRequest.setCookies(
+			new Cookie("intercom-id-test", RandomTestUtil.randomString()),
+			new Cookie("intercom-session-test", RandomTestUtil.randomString()),
+			new Cookie("test-cookie", RandomTestUtil.randomString()));
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	private final MockHttpServletRequest _mockHttpServletRequest =
+		new MockHttpServletRequest();
+
+}

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/java/com/liferay/click/to/chat/web/internal/events/LogoutPreAction.java
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/java/com/liferay/click/to/chat/web/internal/events/LogoutPreAction.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.click.to.chat.web.internal.events;
+
+import com.liferay.click.to.chat.web.internal.configuration.ClickToChatConfiguration;
+import com.liferay.click.to.chat.web.internal.configuration.ClickToChatConfigurationUtil;
+import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
+import com.liferay.portal.kernel.events.Action;
+import com.liferay.portal.kernel.events.LifecycleAction;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jonathan McCann
+ */
+@Component(property = "key=logout.events.pre", service = LifecycleAction.class)
+public class LogoutPreAction extends Action {
+
+	@Override
+	public void run(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		ClickToChatConfiguration clickToChatConfiguration =
+			ClickToChatConfigurationUtil.getClickToChatConfiguration(
+				themeDisplay.getCompanyId(), themeDisplay.getSiteGroupId());
+
+		if ((clickToChatConfiguration == null) ||
+			!clickToChatConfiguration.enabled() ||
+			!StringUtil.equals(
+				clickToChatConfiguration.chatProviderId(), _INTERCOM)) {
+
+			return;
+		}
+
+		try {
+			String domain = CookiesManagerUtil.getDomain(httpServletRequest);
+
+			Cookie[] cookies = httpServletRequest.getCookies();
+
+			for (Cookie cookie : cookies) {
+				String name = cookie.getName();
+
+				if (name.startsWith(_INTERCOM_COOKIE_PREFIX)) {
+					CookiesManagerUtil.deleteCookies(
+						domain, httpServletRequest, httpServletResponse, name);
+				}
+			}
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+	}
+
+	private static final String _INTERCOM = "intercom";
+
+	private static final String _INTERCOM_COOKIE_PREFIX = "intercom-";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LogoutPreAction.class);
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33486

# How am I fixing it?

The cookies created by Intercom to track a user's sessions are being deleted via a logout hook.

The difficult aspect of how this module is implemented is that everything depends on a page load to trigger the Javascript from the various providers. This may not happen for instance if `Guest Users Allowed` is disabled. The fix opts to remove the cookies rather than via [Intercom('shutdown')|https://www.intercom.com/help/en/articles/16845-how-do-i-end-a-session] due to these challenges.

If there are any ideas as to how to trigger the Javascript only when a user has logged out please let me know.

# How can you verify that it works?

From `modules/apps/click-to-chat/click-to-chat-test` run `gw testIntegration --tests *.LogoutPreActionTest`

Manual steps can be found on LPD-33486 but will require an Intercom account.