### PR TITLE
LPD-34097 Setting "noindex" or "nofollow" in robots does not remove page from sitemap

### DIFF
--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/internal/portlet/action/test/EditSEOMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/internal/portlet/action/test/EditSEOMVCActionCommandTest.java
@@ -1,0 +1,214 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.seo.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.admin.kernel.model.LayoutTypePortletConstants;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jonathan McCann
+ */
+@RunWith(Arquillian.class)
+@Sync
+public class EditSEOMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_company = _companyLocalService.getCompany(_group.getCompanyId());
+		_layout = LayoutTestUtil.addTypeContentLayout(_group);
+	}
+
+	@Test
+	public void testSitemapIncludeWithEmptyRobots() throws Exception {
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_setUpMockLiferayPortletActionRequest();
+
+		ReflectionTestUtil.invoke(
+			_mvcActionCommand, "doProcessAction",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		Layout layout = _layoutLocalService.getLayout(_layout.getPlid());
+
+		Assert.assertNull(
+			layout.getTypeSettingsProperty(
+				LayoutTypePortletConstants.SITEMAP_INCLUDE));
+	}
+
+	@Test
+	public void testSitemapIncludeWithNoFollowAndTestRobots() throws Exception {
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_setUpMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"robots_en_US", "nofollow\ntest");
+
+		ReflectionTestUtil.invoke(
+			_mvcActionCommand, "doProcessAction",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		Layout layout = _layoutLocalService.getLayout(_layout.getPlid());
+
+		Assert.assertEquals(
+			"0",
+			layout.getTypeSettingsProperty(
+				LayoutTypePortletConstants.SITEMAP_INCLUDE));
+	}
+
+	@Test
+	public void testSitemapIncludeWithNoFollowRobots() throws Exception {
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_setUpMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"robots_en_US", "nofollow");
+
+		ReflectionTestUtil.invoke(
+			_mvcActionCommand, "doProcessAction",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		Layout layout = _layoutLocalService.getLayout(_layout.getPlid());
+
+		Assert.assertEquals(
+			"0",
+			layout.getTypeSettingsProperty(
+				LayoutTypePortletConstants.SITEMAP_INCLUDE));
+	}
+
+	@Test
+	public void testSitemapIncludeWithNoIndexAndTestRobots() throws Exception {
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_setUpMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"robots_en_US", "noindex\ntest");
+
+		ReflectionTestUtil.invoke(
+			_mvcActionCommand, "doProcessAction",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		Layout layout = _layoutLocalService.getLayout(_layout.getPlid());
+
+		Assert.assertEquals(
+			"0",
+			layout.getTypeSettingsProperty(
+				LayoutTypePortletConstants.SITEMAP_INCLUDE));
+	}
+
+	@Test
+	public void testSitemapIncludeWithNoIndexRobots() throws Exception {
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_setUpMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter("robots_en_US", "noindex");
+
+		ReflectionTestUtil.invoke(
+			_mvcActionCommand, "doProcessAction",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		Layout layout = _layoutLocalService.getLayout(_layout.getPlid());
+
+		Assert.assertEquals(
+			"0",
+			layout.getTypeSettingsProperty(
+				LayoutTypePortletConstants.SITEMAP_INCLUDE));
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(_company);
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private MockLiferayPortletActionRequest
+			_setUpMockLiferayPortletActionRequest()
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockLiferayPortletActionRequest.addParameter(
+			"layoutId", String.valueOf(_layout.getLayoutId()));
+		mockLiferayPortletActionRequest.addParameter(
+			"privateLayout", String.valueOf(_layout.isPrivateLayout()));
+		mockLiferayPortletActionRequest.addParameter("redirect", "fakeURL");
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	private static Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@Inject(filter = "mvc.command.name=/layout/edit_seo")
+	private MVCActionCommand _mvcActionCommand;
+
+}

--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/portlet/action/EditSEOMVCActionCommand.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/portlet/action/EditSEOMVCActionCommand.java
@@ -8,8 +8,10 @@ package com.liferay.layout.seo.web.internal.portlet.action;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.admin.kernel.model.LayoutTypePortletConstants;
 import com.liferay.layout.seo.service.LayoutSEOEntryService;
 import com.liferay.layout.seo.web.internal.util.LayoutTypeSettingsUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -23,6 +25,7 @@ import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropertiesParamUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -97,6 +100,22 @@ public class EditSEOMVCActionCommand extends BaseMVCActionCommand {
 		UnicodeProperties formTypeSettingsUnicodeProperties =
 			PropertiesParamUtil.getProperties(
 				actionRequest, "TypeSettingsProperties--");
+
+		for (Map.Entry<Locale, String> entry : robotsMap.entrySet()) {
+			String value = entry.getValue();
+
+			if (Validator.isNotNull(value) &&
+				(StringUtil.containsIgnoreCase(
+					value, "nofollow", StringPool.BLANK) ||
+				 StringUtil.containsIgnoreCase(
+					 value, "noindex", StringPool.BLANK))) {
+
+				formTypeSettingsUnicodeProperties.setProperty(
+					LayoutTypePortletConstants.SITEMAP_INCLUDE, "0");
+
+				break;
+			}
+		}
 
 		themeDisplay.clearLayoutFriendlyURL(layout);
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-34097

# How am I fixing it?

In https://liferay.atlassian.net/browse/LPD-9969 the field for `Sitemap Include` was disabled whenever the `robots` contained `nofollow` or `noindex`. However, disabled fields are not submitted within forms so in the backend we only received a `null` value - https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/toggleSitemapFields.js#L54-L56

With these changes it checks to see if the robots contain either of those phrases and explicitly sets the `sitemap-include` to `0` (`false`).

# How can you verify that it works?

In `modules/apps/layout/layout-seo-test` run `gw testIntegration --tests *.EditSEOMVCActionCommandTest`

Manual steps can be found on https://liferay.atlassian.net/browse/LPD-34097